### PR TITLE
These tests do not fail on 1.8

### DIFF
--- a/src/h5cpp/property/file_creation.cpp
+++ b/src/h5cpp/property/file_creation.cpp
@@ -113,7 +113,7 @@ unsigned int FileCreationList::btree_rank() const
 
 void FileCreationList::btree_symbols(unsigned int lk)
 {
-  if(0 > H5Pset_sym_k(static_cast<hid_t>(*this), 0, lk))
+  if(0 > H5Pset_sym_k(static_cast<hid_t>(*this),0, lk))
   {
     throw std::runtime_error("Failure setting symbol size parameter for symbol table nodes!");
   }

--- a/test/property/file_creation_test.cpp
+++ b/test/property/file_creation_test.cpp
@@ -126,7 +126,9 @@ TEST(FileCreationList, btree_rank)
   EXPECT_NO_THROW(fcpl.btree_rank(32767));
   EXPECT_EQ(fcpl.btree_rank(), 32767u);
 
+#if H5_VERSION_GE(1,10,0)
   EXPECT_THROW(fcpl.btree_rank(32768), std::runtime_error);
+#endif
 
   hdf5::ObjectHandle(static_cast<hid_t>(fcpl)).close();
   EXPECT_THROW(fcpl.btree_rank(), std::runtime_error);
@@ -166,7 +168,9 @@ TEST(FileCreationList, chunk_tree_rank)
   EXPECT_EQ(fcpl.chunk_tree_rank(), 32767u);
 
   EXPECT_THROW(fcpl.chunk_tree_rank(0), std::runtime_error);
+#if H5_VERSION_GE(1,10,0)
   EXPECT_THROW(fcpl.chunk_tree_rank(32768), std::runtime_error);
+#endif
 
   hdf5::ObjectHandle(static_cast<hid_t>(fcpl)).close();
   EXPECT_THROW(fcpl.chunk_tree_rank(), std::runtime_error);


### PR DESCRIPTION
So the current solution is to remove them from the build 
for 1.8

Update #151