### PR TITLE
Issue 184

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,19 @@ set(EXTRA_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${EXTRA_MODULES_DIR})
 
 #=============================================================================
+# ensure build type first
+#=============================================================================
+
+include(${EXTRA_MODULES_DIR}/CoverageReports.cmake)
+include(${EXTRA_MODULES_DIR}/EnsureBuildType.cmake)
+
+#=============================================================================
 # setting up conan for use from within cmake
 #=============================================================================
 set(WITH_CONAN OFF CACHE BOOL "Enable dependency build with conan")
 set(CONAN_FILE "conanfile_default.txt" CACHE STRING "The conanfile to use for the build")
 
 if (WITH_CONAN)
-  
   include(${EXTRA_MODULES_DIR}/ConanSetup.cmake)
   conan_cmake_run(CONANFILE ${CONAN_FILE}
     BASIC_SETUP
@@ -27,13 +33,10 @@ if (EXISTS ${PROJECT_BINARY_DIR}/conanbuildinfo.cmake)
   conan_basic_setup()
 endif ()
 
-
 #=============================================================================
 # some general configuration
 #=============================================================================
 
-include(${EXTRA_MODULES_DIR}/CoverageReports.cmake)
-include(${EXTRA_MODULES_DIR}/EnsureBuildType.cmake)
 include(${EXTRA_MODULES_DIR}/InstallConfig.cmake)
 include(${EXTRA_MODULES_DIR}/OutputDirConfig.cmake)
 include(${EXTRA_MODULES_DIR}/WindowsUtils.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif ()
 if (EXISTS ${PROJECT_BINARY_DIR}/conanbuildinfo.cmake)
   message(STATUS "Using existing conanbuildinfo.cmake file")
   include(${PROJECT_BINARY_DIR}/conanbuildinfo.cmake)
-  conan_basic_setup()
+  conan_basic_setup(KEEP_RPATHS)
 endif ()
 
 #=============================================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ def get_osx_pipeline()
                     }
 
                     try {
-                        sh "cmake -DCMAKE_MACOSX_RPATH=ON ../code"
+                        sh "cmake -DCMAKE_MACOSX_RPATH=OFF ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ def get_osx_pipeline()
                     }
 
                     try {
-                        sh "cmake -DCMAKE_MACOSX_RPATH=OFF ../code"
+                        sh "cmake ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }
@@ -180,7 +180,7 @@ def get_osx_pipeline()
                     try {
                         sh "make run_tests"
                     } catch (e) {
-		        junit 'test/unit_tests_run.xml'
+		                junit 'test/unit_tests_run.xml'
                         failure_function(e, 'MacOSX / build+test failed')
                     }
                 }
@@ -202,12 +202,10 @@ node {
     }
 
     def builders = [:]
-/*
     for (x in images.keySet()) {
         def image_key = x
         builders[image_key] = get_pipeline(image_key)
     }
-*/
     builders['MocOSX'] = get_osx_pipeline()
     
     parallel builders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ def get_osx_pipeline()
                 dir("${project}/build") {
                     try {
                         // sh "conan install --file=../conanfile_ess.txt --build=missing"
-                        sh "cmake -DWITH_CONAN=ON -DCONAN_FILE=../conanfile_ess.txt ../code"
+                        sh "cmake -DWITH_CONAN=ON -DCONAN_FILE=../code/conanfile_ess.txt ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,9 @@ def docker_dependencies(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         mkdir build
         cd build
+        conan remote add \
+            --insert 0 \
+            ${conan_remote} ${local_conan_server}
         conan install --file=../${project}/conanfile_ess.txt --build=missing
     \""""
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,23 +2,23 @@ project = "h5cpp"
 
 images = [
     'centos': [
-        'name': 'essdmscdm/centos-build-node:0.9.0',
+        'name': 'essdmscdm/centos-build-node:0.9.4',
         'sh': 'sh'
     ],
     'centos-gcc6': [
-        'name': 'essdmscdm/centos-gcc6-build-node:0.3.0',
+        'name': 'essdmscdm/centos-gcc6-build-node:0.3.4',
         'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash'
     ],
     'fedora': [
-        'name': 'essdmscdm/fedora-build-node:0.4.1',
+        'name': 'essdmscdm/fedora-build-node:0.4.2',
         'sh': 'sh'
     ],
     'ubuntu1604': [
-        'name': 'essdmscdm/ubuntu16.04-build-node:0.0.1',
+        'name': 'essdmscdm/ubuntu16.04-build-node:0.0.2',
         'sh': 'sh'
     ],
     'ubuntu1710': [
-        'name': 'essdmscdm/ubuntu17.10-build-node:0.0.2',
+        'name': 'essdmscdm/ubuntu17.10-build-node:0.0.3',
         'sh': 'sh'
     ]
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,18 +196,11 @@ node {
     }
 
     def builders = [:]
-    builders['centos'] = get_pipeline('centos')
-    builders['centos-gcc6'] = get_pipeline('centos-gcc6')
-    builders['fedora'] = get_pipeline('fedora')
-    builders['ubuntu1604'] = get_pipeline('ubuntu1604')
-    //builders['ubuntu1710'] = get_pipeline('ubuntu1710')
-    builders['MocOSX'] = get_osx_pipeline()
-
-    
     for (x in images.keySet()) {
         def image_key = x
         builders[image_key] = get_pipeline(image_key)
     }
+    builders['MocOSX'] = get_osx_pipeline()
     
     parallel builders
 
@@ -215,7 +208,6 @@ node {
     cleanWs()
 }
 
-/*
 node ("fedora") {
     // Delete workspace when build is done
     cleanWs()
@@ -303,4 +295,3 @@ node ("fedora") {
         }
     }
 }
-*/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ def get_osx_pipeline()
                 dir("${project}/build") {
                     try {
                         // sh "conan install --file=../conanfile_ess.txt --build=missing"
-                        sh "cmake -DWITH_CONAN=ON ../code"
+                        sh "cmake -DWITH_CONAN=ON -DCONAN_FILE=../conanfile_ess.txt ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,12 @@ def get_osx_pipeline()
                 dir("${project}/build") {
                     try {
                         sh "conan install --file=../code/conanfile_ess.txt --build=missing"
-                        sh "cmake ../code"
+                    } catch (e) {
+                        failure_function(e, 'MacOSX / getting dependencies failed')
+                    }
+
+                    try {
+                        sh "cmake -DCMAKE_OSX_RPATH=ON ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ def get_osx_pipeline()
                     }
 
                     try {
-                        sh "cmake -DCMAKE_OSX_RPATH=ON ../code"
+                        sh "cmake -DCMAKE_MACOSX_RPATH=ON ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,10 +196,10 @@ node {
     }
 
     def builders = [:]
-    //builders['centos'] = get_pipeline('centos')
-    //builders['centos-gcc6'] = get_pipeline('centos-gcc6')
+    builders['centos'] = get_pipeline('centos')
+    builders['centos-gcc6'] = get_pipeline('centos-gcc6')
     //builders['fedora'] = get_pipeline('fedora')
-    builders['ubuntu1604'] = get_pipeline('ubuntu1604')
+    //builders['ubuntu1604'] = get_pipeline('ubuntu1604')
     //builders['MocOSX'] = get_osx_pipeline()
 
     /*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ def docker_cmake(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         cd build
         ${cmake_exec} --version
-        ${cmake_exec} -DCONAN_FILE=conanfile_ess.txt -DCMAKE_BUILD_TYPE=Release ../${project}
+        ${cmake_exec} ../${project}
     \""""
 }
 
@@ -196,19 +196,19 @@ node {
     }
 
     def builders = [:]
-    //builders['centos'] = get_pipeline('centos')
-    //builders['centos-gcc6'] = get_pipeline('centos-gcc6')
+    builders['centos'] = get_pipeline('centos')
+    builders['centos-gcc6'] = get_pipeline('centos-gcc6')
     builders['fedora'] = get_pipeline('fedora')
-    //builders['ubuntu1604'] = get_pipeline('ubuntu1604')
-    builders['ubuntu1710'] = get_pipeline('ubuntu1710')
-    //builders['MocOSX'] = get_osx_pipeline()
+    builders['ubuntu1604'] = get_pipeline('ubuntu1604')
+    //builders['ubuntu1710'] = get_pipeline('ubuntu1710')
+    builders['MocOSX'] = get_osx_pipeline()
 
-    /*
+    
     for (x in images.keySet()) {
         def image_key = x
         builders[image_key] = get_pipeline(image_key)
     }
-    */
+    
     parallel builders
 
     // Delete workspace when build is done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,10 +202,12 @@ node {
     }
 
     def builders = [:]
+/*
     for (x in images.keySet()) {
         def image_key = x
         builders[image_key] = get_pipeline(image_key)
     }
+*/
     builders['MocOSX'] = get_osx_pipeline()
     
     parallel builders

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,9 +173,10 @@ def get_osx_pipeline()
                     }
 
                     try {
-                        sh "make h5cpp_shared"
+                        sh "make run_tests"
                     } catch (e) {
-                        failure_function(e, 'MacOSX / build failed')
+		        junit 'test/unit_tests_run.xml'
+                        failure_function(e, 'MacOSX / build+test failed')
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,7 @@ def Object get_container(image_key) {
 def get_pipeline(image_key)
 {
     return {
+      node('docker && dmbuild03.dm.esss.dk') {
         stage("${image_key}") {
             try {
                 def container = get_container(image_key)
@@ -147,6 +148,7 @@ def get_pipeline(image_key)
                 sh "docker rm -f ${container_name(image_key)}"
             }
         }
+      }
     }
 }
 
@@ -186,11 +188,7 @@ def get_osx_pipeline()
     }
 }
 
-node('docker && dmbuild03.dm.esss.dk') {
-
-    // Delete workspace when build is done
-    cleanWs()
-
+node {
     stage('Checkout') {
         dir("${project}/code") {
             try {
@@ -215,6 +213,9 @@ node('docker && dmbuild03.dm.esss.dk') {
     }
     */
     parallel builders
+
+    // Delete workspace when build is done
+    cleanWs()
 }
 
 node ("fedora") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,13 +46,6 @@ def docker_dependencies(image_key) {
     sh """docker exec ${container_name(image_key)} ${custom_sh} -c \"
         mkdir build
         cd build
-        conan --version
-        set +x
-        conan remote add \
-        desy-packages https://api.bintray.com/conan/eugenwintersberger/desy-packages
-        conan remote add \
-            --insert 0 \
-            ${conan_remote} ${local_conan_server}
         conan install --file=../${project}/conanfile_ess.txt --build=missing
     \""""
 }
@@ -203,8 +196,8 @@ node {
     //builders['centos'] = get_pipeline('centos')
     //builders['centos-gcc6'] = get_pipeline('centos-gcc6')
     //builders['fedora'] = get_pipeline('fedora')
-    //builders['ubuntu1604'] = get_pipeline('ubuntu1604')
-    builders['MocOSX'] = get_osx_pipeline()
+    builders['ubuntu1604'] = get_pipeline('ubuntu1604')
+    //builders['MocOSX'] = get_osx_pipeline()
 
     /*
     for (x in images.keySet()) {
@@ -218,6 +211,7 @@ node {
     cleanWs()
 }
 
+/*
 node ("fedora") {
     // Delete workspace when build is done
     cleanWs()
@@ -304,5 +298,5 @@ node ("fedora") {
             }
         }
     }
-
 }
+*/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,8 +170,8 @@ def get_osx_pipeline()
 
                 dir("${project}/build") {
                     try {
-                        // sh "conan install --file=../conanfile_ess.txt --build=missing"
-                        sh "cmake -DWITH_CONAN=ON -DCONAN_FILE=../code/conanfile_ess.txt ../code"
+                        sh "conan install --file=../code/conanfile_ess.txt --build=missing"
+                        sh "cmake ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,10 +196,11 @@ node {
     }
 
     def builders = [:]
-    builders['centos'] = get_pipeline('centos')
-    builders['centos-gcc6'] = get_pipeline('centos-gcc6')
-    //builders['fedora'] = get_pipeline('fedora')
+    //builders['centos'] = get_pipeline('centos')
+    //builders['centos-gcc6'] = get_pipeline('centos-gcc6')
+    builders['fedora'] = get_pipeline('fedora')
     //builders['ubuntu1604'] = get_pipeline('ubuntu1604')
+    builders['ubuntu1710'] = get_pipeline('ubuntu1710')
     //builders['MocOSX'] = get_osx_pipeline()
 
     /*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,8 @@ def get_osx_pipeline()
 
                 dir("${project}/build") {
                     try {
-                        sh "cmake ../code"
+                        // sh "conan install --file=../conanfile_ess.txt --build=missing"
+                        sh "cmake -DWITH_CONAN=ON ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }
@@ -201,10 +202,10 @@ node('docker && dmbuild03.dm.esss.dk') {
     }
 
     def builders = [:]
-    builders['centos'] = get_pipeline('centos')
-    builders['centos-gcc6'] = get_pipeline('centos-gcc6')
-    builders['fedora'] = get_pipeline('fedora')
-    builders['ubuntu1604'] = get_pipeline('ubuntu1604')
+    //builders['centos'] = get_pipeline('centos')
+    //builders['centos-gcc6'] = get_pipeline('centos-gcc6')
+    //builders['fedora'] = get_pipeline('fedora')
+    //builders['ubuntu1604'] = get_pipeline('ubuntu1604')
     builders['MocOSX'] = get_osx_pipeline()
 
     /*

--- a/cmake/InstallConfig.cmake
+++ b/cmake/InstallConfig.cmake
@@ -23,7 +23,6 @@ elseif(CMAKE_SYSTEM_NAME MATCHES Darwin)
   include(GNUInstallDirs)
   message(STATUS "==============================================================")
   message(STATUS "Installation directories for MacOSX: ")
-
   set(CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}-${PROJECT_VERSION})
 
 elseif(CMAKE_SYSTEM_NAME MATCHES Windows)

--- a/cmake/InstallConfig.cmake
+++ b/cmake/InstallConfig.cmake
@@ -21,6 +21,7 @@ elseif(CMAKE_SYSTEM_NAME MATCHES Darwin)
   # on OSX we can also use GNUInstallDirs module to
   # determine the installation paths
   include(GNUInstallDirs)
+
   message(STATUS "==============================================================")
   message(STATUS "Installation directories for MacOSX: ")
   set(CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}-${PROJECT_VERSION})
@@ -43,10 +44,6 @@ elseif(CMAKE_SYSTEM_NAME MATCHES Windows)
 
     message(STATUS "==============================================================")
     message(STATUS "Installation directories for Windows: ")
-    
-elseif(CMAKE_SYSTEM_NAME MATCHES Darwin)
-    
-    # add here configuration for OSX
 
 endif()
 

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -2,7 +2,6 @@
 Boost/1.62.0@ess-dmsc/stable
 hdf5/1.10.1-dm3@ess-dmsc/testing
 gtest/3121b20-dm1@ess-dmsc/testing
-#zlib/1.2.8@conan/stable
 cmake_installer/1.0@conan/stable
 
 [generators]

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -1,6 +1,6 @@
 [requires]
 Boost/1.62.0@ess-dmsc/stable
-hdf5/1.10.1-dm1@ess-dmsc/stable
+hdf5/1.10.1-dm3@ess-dmsc/stable
 gtest/3121b20-dm1@ess-dmsc/testing
 #zlib/1.2.8@conan/stable
 cmake_installer/1.0@conan/stable

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -1,6 +1,6 @@
 [requires]
 Boost/1.62.0@ess-dmsc/stable
-hdf5/1.10.1-dm3@ess-dmsc/stable
+hdf5/1.10.1-dm3@ess-dmsc/testing
 gtest/3121b20-dm1@ess-dmsc/testing
 #zlib/1.2.8@conan/stable
 cmake_installer/1.0@conan/stable

--- a/src/h5cpp/CMakeLists.txt
+++ b/src/h5cpp/CMakeLists.txt
@@ -23,6 +23,11 @@ add_library(h5cpp_shared SHARED
   ${h5cpp_headers}
   )
 
+if(CMAKE_SYSTEM_NAME MATCHES Darwin)
+  set_target_properties(h5cpp_shared PROPERTIES INSTALL_RPATH "${INSTALL_PREFIX}/lib")
+  set_target_properties(h5cpp_shared PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
+endif()
+    
 target_compile_definitions(h5cpp_shared PRIVATE DLL_BUILD)
 set(H5CPP_LINKS ${HDF5_LIBRARIES} Boost::filesystem ${MPI_CXX_LIBRARIES})
 target_include_directories(h5cpp_shared

--- a/src/h5cpp/CMakeLists.txt
+++ b/src/h5cpp/CMakeLists.txt
@@ -23,11 +23,6 @@ add_library(h5cpp_shared SHARED
   ${h5cpp_headers}
   )
 
-#if(CMAKE_SYSTEM_NAME MATCHES Darwin)
-#  set_target_properties(h5cpp_shared PROPERTIES INSTALL_RPATH "${INSTALL_PREFIX}/lib")
-#  set_target_properties(h5cpp_shared PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
-#endif()
-
 target_compile_definitions(h5cpp_shared PRIVATE DLL_BUILD)
 set(H5CPP_LINKS ${HDF5_LIBRARIES} Boost::filesystem ${MPI_CXX_LIBRARIES})
 target_include_directories(h5cpp_shared

--- a/src/h5cpp/CMakeLists.txt
+++ b/src/h5cpp/CMakeLists.txt
@@ -23,11 +23,11 @@ add_library(h5cpp_shared SHARED
   ${h5cpp_headers}
   )
 
-if(CMAKE_SYSTEM_NAME MATCHES Darwin)
-  set_target_properties(h5cpp_shared PROPERTIES INSTALL_RPATH "${INSTALL_PREFIX}/lib")
-  set_target_properties(h5cpp_shared PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
-endif()
-    
+#if(CMAKE_SYSTEM_NAME MATCHES Darwin)
+#  set_target_properties(h5cpp_shared PROPERTIES INSTALL_RPATH "${INSTALL_PREFIX}/lib")
+#  set_target_properties(h5cpp_shared PROPERTIES BUILD_WITH_INSTALL_RPATH ON)
+#endif()
+
 target_compile_definitions(h5cpp_shared PRIVATE DLL_BUILD)
 set(H5CPP_LINKS ${HDF5_LIBRARIES} Boost::filesystem ${MPI_CXX_LIBRARIES})
 target_include_directories(h5cpp_shared


### PR DESCRIPTION
This is kind of urgent and no actual code has changed, mostly Jenkins, so I will probably merge it if you are unreachable to look it over. Basically, the changes have to do with this:
1. Jenkins OSX node now build using Conan (closing #177)
2. Jenkins OSX node also builds and runs tests! (closing #184)
3. Jenkins now tests all of the platforms previously discussed, except windows: centos7, centos7+gcc6, fedora 25, ubuntu 16.04 (latest LTS), ubuntu 17.10 (latest non-LTS), OSX (closing #115)
4. This sets the stage for automatically built and maintained Conan packages for h5cpp. This is the real reason for doing all of this. We need to bring more of our projects on board to use this library. I have created a new ticket for this: #186 

This actually took a lot longer than it may seem, as this RPATH-related issue on OSX was quite hard to track down. In the end the fix was a one-liner :)