### PR TITLE
Issue 163

### DIFF
--- a/src/h5cpp/core/object_handle.cpp
+++ b/src/h5cpp/core/object_handle.cpp
@@ -28,17 +28,16 @@
 #include <sstream>
 #include <h5cpp/error/error.hpp>
 
-namespace hdf5
-{
+namespace hdf5 {
 
 //=================constrcutors and destructors============================
-ObjectHandle::ObjectHandle(hid_t id,ObjectHandle::Policy policy)
-  :handle_(id)
+ObjectHandle::ObjectHandle(hid_t id, ObjectHandle::Policy policy)
+    : handle_(id)
 {
-  if(handle_<0)
+  if (handle_ < 0)
   {
     std::stringstream ss;
-    ss<<"Invalid object handler ("<<id<<")";
+    ss << "Invalid object handler (" << id << ")";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
 
@@ -46,59 +45,66 @@ ObjectHandle::ObjectHandle(hid_t id,ObjectHandle::Policy policy)
   // if we do not care about the object we have to increment its reference count
   // in order to avoid getting it destroyed when the ID looses scope.
   //
-  if(policy == Policy::WITHOUT_WARD)
+  if (policy == Policy::WITHOUT_WARD)
     increment_reference_count();
 }
-    
-//-------------------------------------------------------------------------
-ObjectHandle::ObjectHandle() noexcept :handle_(0) { }
 
 //-------------------------------------------------------------------------
-ObjectHandle::ObjectHandle(const ObjectHandle &o) 
-    :handle_(o.handle_)
+ObjectHandle::ObjectHandle() noexcept : handle_(0) {}
+
+//-------------------------------------------------------------------------
+ObjectHandle::ObjectHandle(const ObjectHandle &o)
+    : handle_(o.handle_)
 {
   //need to increment the reference 
   //counter for this object as we do copy construction
-  if(is_valid()) increment_reference_count();
+  if (is_valid()) increment_reference_count();
 }
 
 //-------------------------------------------------------------------------
 ObjectHandle::ObjectHandle(ObjectHandle &&o) noexcept
-    :handle_(o.handle_) 
+    : handle_(o.handle_)
 {
   o.handle_ = 0;
   //since the id is removed from the original object we do not
   //have to care about the reference counter
 }
-    
+
 //-------------------------------------------------------------------------
 ObjectHandle::~ObjectHandle()
 {
   try
   {
-    close();
+    if (is_valid())
+      close();
+  }
+  catch (std::runtime_error &e)
+  {
+    // This should almost never happen, unless is_valid() threw
+    std::cerr << "Failed ~ObjectHandle:\n" << hdf5::error::print_nested(e, 1);
   }
   catch (...)
   {
-    // nothing clever to do here
-    // this should never happen
-    // perhaps close() should ne noexcept?
+    // Pokemon clause
+    // ensures noexcept behavior
   }
-}   
-
+}
 
 //================assignment operators=====================================
 //implementation of the copy assignment operator
 ObjectHandle &ObjectHandle::operator=(const ObjectHandle &o)
 {
-  if(this == &o) return *this;
+  if (this == &o) return *this;
 
-  close(); //close the current object
+  //close the current object
+  if (is_valid())
+    close();
+
   handle_ = o.handle_;
 
   //if the original object is valid we have to increment 
   //the reference counter for this id
-  if(is_valid()) increment_reference_count();
+  if (is_valid()) increment_reference_count();
 
   return *this;
 }
@@ -107,9 +113,20 @@ ObjectHandle &ObjectHandle::operator=(const ObjectHandle &o)
 //implementation of the move assignment operator
 ObjectHandle &ObjectHandle::operator=(ObjectHandle &&o) noexcept
 {
-  if(this == &o) return *this;
+  if (this == &o) return *this;
 
-  close(); //need to close the original object here 
+  //need to close the original object here
+  try
+  {
+    if (is_valid())
+      close();
+  }
+  catch (...)
+  {
+    // Pokemon clause
+    // to ensure noexcept behavior
+  }
+
   handle_ = o.handle_;
   o.handle_ = 0;
 
@@ -119,129 +136,134 @@ ObjectHandle &ObjectHandle::operator=(ObjectHandle &&o) noexcept
   return *this;
 }
 
-
-   
 //=============basic manipulation methods==================================
-bool ObjectHandle::is_valid() const 
+bool ObjectHandle::is_valid() const
 {
-  if(handle_==0) return false;
+  if (handle_ == 0) return false;
 
   htri_t value = H5Iis_valid(handle_);
-  
-  if(value < 0)
+
+  if (value < 0)
   {
     std::stringstream ss;
-    ss<<"Could not retrieve validity status for handle ("<<handle_<<")";
+    ss << "Could not retrieve validity status for handle (" << handle_ << ")";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
 
-  if(value)
+  if (value)
   {
-      return true;
-  }
-  else 
+    return true;
+  } else
   {
-      return false;
+    return false;
   }
 }
 
 //----------------------------------------------------------------------------
-void ObjectHandle::close() 
+void ObjectHandle::close()
 {
   //if the ID is valid this will decrement the reference counter or close
   //the object if the counter becomes 0.
 
-  if(is_valid())
+  ObjectHandle::Type oht{Type::UNINITIALIZED};
+
+  try
   {
-    herr_t error_code = 0;
+    oht = get_type();
+  }
+  catch (...)
+  {
+    std::stringstream ss;
+    ss << "Could not close object handle (" << handle_ << ")!";
+    std::throw_with_nested(std::runtime_error(ss.str()));
+  }
 
-    switch(get_type())
-    {
-      case ObjectHandle::Type::DATASPACE: 
-        error_code = H5Sclose(handle_);
-        break;
-      case ObjectHandle::Type::DATATYPE:
-        error_code = H5Tclose(handle_);
-        break;
-      case ObjectHandle::Type::ATTRIBUTE:
-        error_code = H5Aclose(handle_);
-        break;
-      case ObjectHandle::Type::FILE:
-        error_code = H5Fclose(handle_);
-        break;
-      case ObjectHandle::Type::PROPERTY_LIST:
-        error_code = H5Pclose(handle_);
-        break;
-      case ObjectHandle::Type::PROPERTY_LIST_CLASS:
-        error_code = H5Pclose_class(handle_);
-        break;
-      case ObjectHandle::Type::ERROR_MESSAGE:
-        error_code = H5Eclose_msg(handle_);
-        break;
-      case ObjectHandle::Type::ERROR_STACK:
-        error_code = H5Eclose_stack(handle_);
-        break;
-      case ObjectHandle::Type::ERROR_CLASS:
-        error_code = H5Eunregister_class(handle_);
-        break;
-      default:
-        error_code = H5Oclose(handle_);
-    }
+  herr_t error_code = 0;
+  switch (oht)
+  {
+    case ObjectHandle::Type::DATASPACE:
+      error_code = H5Sclose(handle_);
+      break;
+    case ObjectHandle::Type::DATATYPE:
+      error_code = H5Tclose(handle_);
+      break;
+    case ObjectHandle::Type::ATTRIBUTE:
+      error_code = H5Aclose(handle_);
+      break;
+    case ObjectHandle::Type::FILE:
+      error_code = H5Fclose(handle_);
+      break;
+    case ObjectHandle::Type::PROPERTY_LIST:
+      error_code = H5Pclose(handle_);
+      break;
+    case ObjectHandle::Type::PROPERTY_LIST_CLASS:
+      error_code = H5Pclose_class(handle_);
+      break;
+    case ObjectHandle::Type::ERROR_MESSAGE:
+      error_code = H5Eclose_msg(handle_);
+      break;
+    case ObjectHandle::Type::ERROR_STACK:
+      error_code = H5Eclose_stack(handle_);
+      break;
+    case ObjectHandle::Type::ERROR_CLASS:
+      error_code = H5Eunregister_class(handle_);
+      break;
+    default:
+      error_code = H5Oclose(handle_);
+  }
 
-    if(error_code<0)
-    {
-      //TODO: maybe we should add here an entry to the error stack
-      std::stringstream ss;
-      ss<<"Could not close object of type "<<get_type()<<"with handle "
-        <<"("<<handle_<<")!";
-      error::Singleton::instance().throw_with_stack(ss.str());
-    }
+  if (error_code < 0)
+  {
+    std::stringstream ss;
+    ss << "Could not close object of type " << oht << "with handle "
+       << "(" << handle_ << ")!";
+    error::Singleton::instance().throw_with_stack(ss.str());
   }
 
   //in any case we have to reset the ID of the obejct
-  handle_ = 0; 
+  handle_ = 0;
 }
 
 //-----------------------------------------------------------------------------
 ObjectHandle::Type ObjectHandle::get_type() const
 {
   H5I_type_t type = H5Iget_type(handle_);
-  
-  switch(type)
+
+  switch (type)
   {
-    case H5I_UNINIT: 
-      return ObjectHandle::Type::UNINITIALIZED;	
-    case H5I_BADID:  
+    case H5I_UNINIT:
+      return ObjectHandle::Type::UNINITIALIZED;
+    case H5I_BADID:
       return ObjectHandle::Type::BADOBJECT;
-    case H5I_FILE: 	
+    case H5I_FILE:
       return ObjectHandle::Type::FILE;
-    case H5I_GROUP: 
+    case H5I_GROUP:
       return ObjectHandle::Type::GROUP;
-    case H5I_DATATYPE: 
+    case H5I_DATATYPE:
       return ObjectHandle::Type::DATATYPE;
-    case H5I_DATASPACE: 
+    case H5I_DATASPACE:
       return ObjectHandle::Type::DATASPACE;
-    case H5I_DATASET: 
+    case H5I_DATASET:
       return ObjectHandle::Type::DATASET;
-    case H5I_ATTR: 
+    case H5I_ATTR:
       return ObjectHandle::Type::ATTRIBUTE;
-    case H5I_REFERENCE: 
+    case H5I_REFERENCE:
       return ObjectHandle::Type::REFERENCE;
-    case H5I_VFL: 
+    case H5I_VFL:
       return ObjectHandle::Type::VIRTUAL_FILE_LAYER;
-    case H5I_GENPROP_CLS: 
+    case H5I_GENPROP_CLS:
       return ObjectHandle::Type::PROPERTY_LIST_CLASS;
-    case H5I_GENPROP_LST: 
+    case H5I_GENPROP_LST:
       return ObjectHandle::Type::PROPERTY_LIST;
-    case H5I_ERROR_CLASS: 
+    case H5I_ERROR_CLASS:
       return ObjectHandle::Type::ERROR_CLASS;
-    case H5I_ERROR_MSG: 
+    case H5I_ERROR_MSG:
       return ObjectHandle::Type::ERROR_MESSAGE;
-    case H5I_ERROR_STACK: 
+    case H5I_ERROR_STACK:
       return ObjectHandle::Type::ERROR_STACK;
     default:
       std::stringstream ss;
-      ss<<"Unkown object type ("<<type<<")";
+      ss << "Unkown object type (" << type << ")";
       error::Singleton::instance().throw_with_stack(ss.str());
   };
 }
@@ -249,23 +271,19 @@ ObjectHandle::Type ObjectHandle::get_type() const
 //----------------------------------------------------------------------------
 void ObjectHandle::increment_reference_count() const
 {
-  if(H5Iinc_ref(handle_)<0)
+  if (H5Iinc_ref(handle_) < 0)
   {
-    //TODO error handling
-    
     //Failing to succesfully inrement the reference counter for an internal
     //object ID is a serious issue and justifies to throw an exception here.
     error::Singleton::instance().throw_with_stack("Error incrementing the reference counter!");
   }
 }
 
-
 //----------------------------------------------------------------------------
 void ObjectHandle::decrement_reference_count() const
 {
-  if(H5Idec_ref(handle_)<0)
+  if (H5Idec_ref(handle_) < 0)
   {
-    //TODO: maybe we should add an entry here on the error stack
     error::Singleton::instance().throw_with_stack("Could not decrement the reference counter");
   }
 }
@@ -274,9 +292,8 @@ void ObjectHandle::decrement_reference_count() const
 int ObjectHandle::get_reference_count() const
 {
   int ref_cnt = H5Iget_ref(handle_);
-  if(ref_cnt<0)
+  if (ref_cnt < 0)
   {
-    //TODO: maybe we should add here an entry to the error stack.
     error::Singleton::instance().throw_with_stack("Could not retrieve reference count for object!");
   }
 
@@ -285,85 +302,114 @@ int ObjectHandle::get_reference_count() const
 
 //=============comparison operators========================================
 //implementation of equality check
-bool operator==(const ObjectHandle &lhs,const ObjectHandle &rhs)
+bool operator==(const ObjectHandle &lhs, const ObjectHandle &rhs)
 {
   //if one of the object is not valid they are considered as in not-equal
-  if((!rhs.is_valid()) || (!lhs.is_valid())) return false;
-  
-  return static_cast<hid_t>(lhs)==static_cast<hid_t>(rhs);
+  if ((!rhs.is_valid()) || (!lhs.is_valid())) return false;
+
+  return static_cast<hid_t>(lhs) == static_cast<hid_t>(rhs);
 }
 
 //-------------------------------------------------------------------------
 //implementation of inequality check
-bool operator!=(const ObjectHandle &a,const ObjectHandle &b)
+bool operator!=(const ObjectHandle &a, const ObjectHandle &b)
 {
-    if(a == b) 
-    {
-      return false;
-    }
-    else
-    {
-      return true;
-    }
+  if (a == b)
+  {
+    return false;
+  } else
+  {
+    return true;
+  }
 }
 
 //----------------------------------------------------------------------------
-std::ostream &operator<<(std::ostream &stream,const ObjectHandle::Type &type)
+std::ostream &operator<<(std::ostream &stream, const ObjectHandle::Type &type)
 {
-  switch(type)
+  switch (type)
   {
-    case ObjectHandle::Type::UNINITIALIZED: stream<<"UNINITIALIZED"; break;
-    case ObjectHandle::Type::BADOBJECT: stream<<"BADOBJECT"; break;
-    case ObjectHandle::Type::FILE: stream<<"FILE"; break;
-    case ObjectHandle::Type::GROUP: stream<<"GROUP"; break;
-    case ObjectHandle::Type::DATATYPE: stream<<"DATATYPE"; break;
-    case ObjectHandle::Type::DATASPACE: stream<<"DATASPACE"; break;
-    case ObjectHandle::Type::DATASET: stream<<"DATASET"; break;
-    case ObjectHandle::Type::ATTRIBUTE: stream<<"ATTRIBUTE"; break;
-    case ObjectHandle::Type::PROPERTY_LIST: stream<<"PROPERTY_LIST"; break;
-    case ObjectHandle::Type::REFERENCE: stream<<"REFERENCE"; break;
-    case ObjectHandle::Type::VIRTUAL_FILE_LAYER: stream<<"VIRTUAL_FILE_LAYER"; break;
-    case ObjectHandle::Type::PROPERTY_LIST_CLASS: stream<<"PROPERTY_LIST_CLASS"; break;
-    case ObjectHandle::Type::ERROR_CLASS: stream<<"ERROR_CLASS"; break;
-    case ObjectHandle::Type::ERROR_MESSAGE: stream<<"ERROR_MESSAGE"; break;
-    case ObjectHandle::Type::ERROR_STACK: stream<<"ERROR_STACK"; break;
+    case ObjectHandle::Type::UNINITIALIZED:
+      stream << "UNINITIALIZED";
+      break;
+    case ObjectHandle::Type::BADOBJECT:
+      stream << "BADOBJECT";
+      break;
+    case ObjectHandle::Type::FILE:
+      stream << "FILE";
+      break;
+    case ObjectHandle::Type::GROUP:
+      stream << "GROUP";
+      break;
+    case ObjectHandle::Type::DATATYPE:
+      stream << "DATATYPE";
+      break;
+    case ObjectHandle::Type::DATASPACE:
+      stream << "DATASPACE";
+      break;
+    case ObjectHandle::Type::DATASET:
+      stream << "DATASET";
+      break;
+    case ObjectHandle::Type::ATTRIBUTE:
+      stream << "ATTRIBUTE";
+      break;
+    case ObjectHandle::Type::PROPERTY_LIST:
+      stream << "PROPERTY_LIST";
+      break;
+    case ObjectHandle::Type::REFERENCE:
+      stream << "REFERENCE";
+      break;
+    case ObjectHandle::Type::VIRTUAL_FILE_LAYER:
+      stream << "VIRTUAL_FILE_LAYER";
+      break;
+    case ObjectHandle::Type::PROPERTY_LIST_CLASS:
+      stream << "PROPERTY_LIST_CLASS";
+      break;
+    case ObjectHandle::Type::ERROR_CLASS:
+      stream << "ERROR_CLASS";
+      break;
+    case ObjectHandle::Type::ERROR_MESSAGE:
+      stream << "ERROR_MESSAGE";
+      break;
+    case ObjectHandle::Type::ERROR_STACK:
+      stream << "ERROR_STACK";
+      break;
     default:
-                                            stream<<"unknown";
+      stream << "unknown";
   };
 
   return stream;
 }
 
-std::istream &operator>>(std::istream &stream,ObjectHandle::Type &type)
+std::istream &operator>>(std::istream &stream, ObjectHandle::Type &type)
 {
   std::string buffer;
 
   //TODO: maybe we should add here a to-upper conversion to allow mixed case strings
-  stream>>buffer;
+  stream >> buffer;
 
-  if(buffer == "FILE")
+  if (buffer == "FILE")
     type = ObjectHandle::Type::FILE;
-  else if(buffer == "GROUP")
+  else if (buffer == "GROUP")
     type = ObjectHandle::Type::GROUP;
-  else if(buffer == "DATATYPE")
+  else if (buffer == "DATATYPE")
     type = ObjectHandle::Type::DATATYPE;
-  else if(buffer == "DATASPACE")
+  else if (buffer == "DATASPACE")
     type = ObjectHandle::Type::DATASPACE;
-  else if(buffer == "DATASET")
+  else if (buffer == "DATASET")
     type = ObjectHandle::Type::DATASET;
-  else if(buffer == "ATTRIBUTE")
+  else if (buffer == "ATTRIBUTE")
     type = ObjectHandle::Type::ATTRIBUTE;
-  else if(buffer == "PROPERTY_LIST")
+  else if (buffer == "PROPERTY_LIST")
     type = ObjectHandle::Type::PROPERTY_LIST;
-  else if(buffer == "REFERENCE")
+  else if (buffer == "REFERENCE")
     type = ObjectHandle::Type::REFERENCE;
-  else if(buffer == "PROPERTY_LIST_CLASS")
+  else if (buffer == "PROPERTY_LIST_CLASS")
     type = ObjectHandle::Type::PROPERTY_LIST_CLASS;
-  else if(buffer == "ERROR_CLASS")
+  else if (buffer == "ERROR_CLASS")
     type = ObjectHandle::Type::ERROR_CLASS;
-  else if(buffer == "ERROR_MESSAGE")
+  else if (buffer == "ERROR_MESSAGE")
     type = ObjectHandle::Type::ERROR_MESSAGE;
-  else if(buffer == "ERROR_STACK")
+  else if (buffer == "ERROR_STACK")
     type = ObjectHandle::Type::ERROR_STACK;
   else
     type = ObjectHandle::Type::BADOBJECT;

--- a/src/h5cpp/core/object_handle.cpp
+++ b/src/h5cpp/core/object_handle.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Aug 07, 2017
 //
 

--- a/src/h5cpp/core/object_handle.hpp
+++ b/src/h5cpp/core/object_handle.hpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Aug 07, 2017
 //
 

--- a/src/h5cpp/core/object_handle.hpp
+++ b/src/h5cpp/core/object_handle.hpp
@@ -178,8 +178,7 @@ class DLL_EXPORT ObjectHandle
     //-----------------------------------------------------------------
     //!
     //! \brief destructor
-    //! 
-    //! \throws std::runtime_error in case of errors
+    //!
     ~ObjectHandle() noexcept;
 
     //================assignment operators=============================

--- a/test/core/ObjectHandleDefault.cpp
+++ b/test/core/ObjectHandleDefault.cpp
@@ -122,6 +122,7 @@ TEST_P(ObjHandleFixture, Types)
   test_->test_copy_construction();
   test_->test_move_construction();
   test_->test_close_pathology();
+  test_->test_equality();
 }
 
 INSTANTIATE_TEST_CASE_P(ObjHandleTest, ObjHandleFixture,

--- a/test/core/ObjectHandleDefault.cpp
+++ b/test/core/ObjectHandleDefault.cpp
@@ -46,7 +46,10 @@ class ObjHandleFixture : public TestWithParam<hdf5::ObjectHandle::Type>
 
     virtual void SetUp()
     {
-      name_ = string_from_type(GetParam());
+      std::stringstream ss;
+      ss << GetParam();
+      name_ = ss.str();
+
       switch(GetParam())
       {
       case hdf5::ObjectHandle::Type::FILE:
@@ -106,7 +109,7 @@ TEST(ObjHandleTest, DefaultConstruction)
   EXPECT_FALSE(handle.is_valid());
   EXPECT_EQ(handle.get_type(),hdf5::ObjectHandle::Type::BADOBJECT);
   EXPECT_THROW(handle.get_reference_count(),std::runtime_error);
-  EXPECT_NO_THROW(handle.close());
+  EXPECT_THROW(handle.close(),std::runtime_error);
 }
 
 TEST_P(ObjHandleFixture, Types)
@@ -118,6 +121,7 @@ TEST_P(ObjHandleFixture, Types)
   test_->test_move_assignment();
   test_->test_copy_construction();
   test_->test_move_construction();
+  test_->test_close_pathology();
 }
 
 INSTANTIATE_TEST_CASE_P(ObjHandleTest, ObjHandleFixture,

--- a/test/core/ObjectHandleDefault.cpp
+++ b/test/core/ObjectHandleDefault.cpp
@@ -20,7 +20,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Aug 14, 2017
 //
 #include <gtest/gtest.h>

--- a/test/core/object_handle_test.cpp
+++ b/test/core/object_handle_test.cpp
@@ -82,16 +82,14 @@ void ObjectHandleTest::test_move_assignment()
   EXPECT_EQ(handle2.get_reference_count(),1);
 }
 
-
-hdf5::ObjectHandle::Type ObjectHandleTest::get_type() const
+void ObjectHandleTest::test_close_pathology()
 {
-  return type_;
-}
+  hdf5::ObjectHandle handle(create_object());
+  EXPECT_NO_THROW(handle.close());
+  EXPECT_THROW(handle.close(), std::runtime_error);
 
-std::string string_from_type(hdf5::ObjectHandle::Type type)
-{
-  std::stringstream ss;
-  ss<<type;
-  return ss.str();
+  hdf5::ObjectHandle* h2 = new hdf5::ObjectHandle(create_object());
+  EXPECT_TRUE(h2->is_valid());
+  EXPECT_NO_THROW(h2->close());
+  EXPECT_NO_THROW((delete h2));
 }
-

--- a/test/core/object_handle_test.cpp
+++ b/test/core/object_handle_test.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Aug 14, 2017
 //
 

--- a/test/core/object_handle_test.cpp
+++ b/test/core/object_handle_test.cpp
@@ -93,3 +93,16 @@ void ObjectHandleTest::test_close_pathology()
   EXPECT_NO_THROW(h2->close());
   EXPECT_NO_THROW((delete h2));
 }
+
+void ObjectHandleTest::test_equality()
+{
+  hdf5::ObjectHandle handle(create_object());
+  hdf5::ObjectHandle handle2 = handle;
+  hdf5::ObjectHandle handle3;
+
+  EXPECT_TRUE(handle == handle2);
+  EXPECT_TRUE(handle != handle3);
+
+  EXPECT_FALSE(handle != handle2);
+  EXPECT_FALSE(handle == handle3);
+}

--- a/test/core/object_handle_test.hpp
+++ b/test/core/object_handle_test.hpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Aug 14, 2017
 //
 #pragma once

--- a/test/core/object_handle_test.hpp
+++ b/test/core/object_handle_test.hpp
@@ -30,35 +30,37 @@
 
 class TestEnvironment
 {
-    hdf5::ObjectHandle file_handle_;
-  public:
-    TestEnvironment(const std::string &filename);
-    void close();
+  hdf5::ObjectHandle file_handle_;
+ public:
+  TestEnvironment(const std::string &filename);
+  void close();
 
-    const hdf5::ObjectHandle &file_handle() const;
+  const hdf5::ObjectHandle &file_handle() const;
 
 };
 
 class ObjectHandleTest
 {
-  private:
-    hdf5::ObjectHandle::Type type_;
-  public:
-    ObjectHandleTest(hdf5::ObjectHandle::Type type);
+ private:
+  hdf5::ObjectHandle::Type type_;
+ public:
+  ObjectHandleTest(hdf5::ObjectHandle::Type type);
 
-    virtual ~ObjectHandleTest();
+  virtual ~ObjectHandleTest();
 
-    virtual hid_t create_object() = 0;
+  virtual hid_t create_object() = 0;
 
-    virtual void test_copy_construction();
+  virtual void test_copy_construction();
 
-    virtual void test_move_construction();
+  virtual void test_move_construction();
 
-    virtual void test_copy_assignment();
+  virtual void test_copy_assignment();
 
-    virtual void test_move_assignment();
+  virtual void test_move_assignment();
 
-    virtual void test_close_pathology();
+  virtual void test_close_pathology();
+
+  virtual void test_equality();
 
   hdf5::ObjectHandle::Type get_type() const { return type_; }
 
@@ -66,103 +68,103 @@ class ObjectHandleTest
 
 class FileObjectHandleTest : public ObjectHandleTest
 {
-  private:
-    std::string filename_;
-  public:
-    FileObjectHandleTest(const std::string &filename);
-    ~FileObjectHandleTest();
+ private:
+  std::string filename_;
+ public:
+  FileObjectHandleTest(const std::string &filename);
+  ~FileObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class DatatypeObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    DatatypeObjectHandleTest();
+ public:
+  DatatypeObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class DataspaceObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    DataspaceObjectHandleTest();
+ public:
+  DataspaceObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class GroupObjectHandleTest : public ObjectHandleTest
 {
-  private:
-    TestEnvironment environment_;
-  public:
-    GroupObjectHandleTest(const std::string &filename);
+ private:
+  TestEnvironment environment_;
+ public:
+  GroupObjectHandleTest(const std::string &filename);
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class DatasetObjectHandleTest : public ObjectHandleTest
 {
-  private:
-    std::string filename_;
-    TestEnvironment environment_;
-    hdf5::ObjectHandle dtype_;
-    hdf5::ObjectHandle dspace_;
-  public:
-    DatasetObjectHandleTest(const std::string &filename);
-    ~DatasetObjectHandleTest();
+ private:
+  std::string filename_;
+  TestEnvironment environment_;
+  hdf5::ObjectHandle dtype_;
+  hdf5::ObjectHandle dspace_;
+ public:
+  DatasetObjectHandleTest(const std::string &filename);
+  ~DatasetObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class AttributeObjectHandleTest : public ObjectHandleTest
 {
-  private:
-    std::string filename_;
-    TestEnvironment environment_;
-    hdf5::ObjectHandle group_;
-  public:
-    AttributeObjectHandleTest(const std::string &filename);
-    ~AttributeObjectHandleTest();
+ private:
+  std::string filename_;
+  TestEnvironment environment_;
+  hdf5::ObjectHandle group_;
+ public:
+  AttributeObjectHandleTest(const std::string &filename);
+  ~AttributeObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class PropertyListObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    PropertyListObjectHandleTest();
+ public:
+  PropertyListObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class PropertyListClassObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    PropertyListClassObjectHandleTest();
+ public:
+  PropertyListClassObjectHandleTest();
 
-    virtual hid_t create_object();
+  virtual hid_t create_object();
 };
 
 class ErrorMessageObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    ErrorMessageObjectHandleTest();
-    virtual hid_t create_object();
+ public:
+  ErrorMessageObjectHandleTest();
+  virtual hid_t create_object();
 };
 
 class ErrorStackObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    ErrorStackObjectHandleTest();
-    virtual hid_t create_object();
+ public:
+  ErrorStackObjectHandleTest();
+  virtual hid_t create_object();
 };
 
 class ErrorClassObjectHandleTest : public ObjectHandleTest
 {
-  public:
-    ErrorClassObjectHandleTest();
-    virtual hid_t create_object();
+ public:
+  ErrorClassObjectHandleTest();
+  virtual hid_t create_object();
 };
 
 

--- a/test/core/object_handle_test.hpp
+++ b/test/core/object_handle_test.hpp
@@ -58,11 +58,11 @@ class ObjectHandleTest
 
     virtual void test_move_assignment();
 
-    hdf5::ObjectHandle::Type get_type() const;
+    virtual void test_close_pathology();
+
+  hdf5::ObjectHandle::Type get_type() const { return type_; }
 
 };
-
-std::string string_from_type(hdf5::ObjectHandle::Type type);
 
 class FileObjectHandleTest : public ObjectHandleTest
 {

--- a/test/file/file_creation_test.cpp
+++ b/test/file/file_creation_test.cpp
@@ -63,7 +63,7 @@ TEST_F(FileCreation, test_default)
   EXPECT_THROW(f.flush(file::Scope::LOCAL),std::runtime_error);
   EXPECT_THROW(f.count_open_objects(file::SearchFlags::ALL),std::runtime_error);
   EXPECT_THROW(f.root(), std::runtime_error);
-  EXPECT_NO_THROW(f.close());
+  EXPECT_THROW(f.close(), std::runtime_error);
 }
 
 TEST_F(FileCreation, test_no_truncate)

--- a/test/file/file_creation_test.cpp
+++ b/test/file/file_creation_test.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Martin Shetty <martin.shetty@esss.se>
 // Created on: Sep 10, 2017
 //
 


### PR DESCRIPTION
* Pretty much the only place that needed a review of this was ObjectHandle.
* ObjectHandle::close() now does not check if the object is valid. If it happens to be not valid, it fails to close and thus throws an exception. If you you use it explicitly anywhere, keep this in mind.
* ObjectHandle destructor, the copy and move operators now perform checks for object validity
* ObjectHandle move operator ensures noexcept behavior. 
* All ObjectHandle functions that may functions that throw also nest the underlying exception with some additional info about the context of the failure
* close, copy and move should now also have a strong(er) exception guarantee
* relevant tests updated
* A bit of a formatting party. Apologies.