### PR TITLE
Test coverage for File classes, including Drivers and MPI-related stuff

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 project = "h5cpp"
-coverage_os = "fedora25-release"
+coverage_os = "centos7-release"
 
 images = [
     'centos7-release': [
         'name': 'essdmscdm/centos7-build-node:1.0.1',
         'sh': 'sh',
-        'cmake_flags': '-DWITH_MPI=1 -DCMAKE_BUILD_TYPE=Release',
+        'cmake_flags': '-DCOV=ON -DWITH_MPI=1 -DCMAKE_BUILD_TYPE=Release',
         'conan_pre': 'CC=/usr/lib64/mpich-3.2/bin/mpicc CXX=/usr/lib64/mpich-3.2/bin/mpicxx ',
         'conan_flags': '-o hdf5:parallel=True'
     ],
@@ -19,7 +19,7 @@ images = [
     'fedora25-release': [
         'name': 'essdmscdm/fedora25-build-node:1.0.0',
         'sh': 'sh',
-        'cmake_flags': '-DCOV=ON -DCMAKE_BUILD_TYPE=Release',
+        'cmake_flags': '-DCMAKE_BUILD_TYPE=Release',
         'conan_pre': '',
         'conan_flags': ''
     ],

--- a/src/h5cpp/file/file.cpp
+++ b/src/h5cpp/file/file.cpp
@@ -19,7 +19,8 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Author: Martin Shetty <martin.shetty@esss.se>
 // Created on: Sep 8, 2017
 //
 
@@ -31,7 +32,7 @@
 namespace hdf5 {
 namespace file {
 
-File::File(ObjectHandle &&handle):
+File::File(ObjectHandle &&handle) :
     handle_(std::move(handle))
 {
 
@@ -40,7 +41,7 @@ File::File(ObjectHandle &&handle):
 AccessFlags File::intent() const
 {
   AccessFlagsBase value;
-  if(H5Fget_intent(static_cast<hid_t>(*this),&value)<0)
+  if (H5Fget_intent(static_cast<hid_t>(*this), &value) < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure retrieving the file intent!");
   }
@@ -51,7 +52,7 @@ AccessFlags File::intent() const
 size_t File::size() const
 {
   hsize_t s;
-  if(H5Fget_filesize(static_cast<hid_t>(*this),&s)<0)
+  if (H5Fget_filesize(static_cast<hid_t>(*this), &s) < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure retrieving the file size!");
   }
@@ -60,7 +61,7 @@ size_t File::size() const
 
 void File::flush(Scope scope) const
 {
-  if(H5Fflush(static_cast<hid_t>(*this),static_cast<H5F_scope_t>(scope))<0)
+  if (H5Fflush(static_cast<hid_t>(*this), static_cast<H5F_scope_t>(scope)) < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure to flush the file!");
   }
@@ -73,29 +74,29 @@ void File::close()
 
 boost::filesystem::path File::path() const
 {
-  ssize_t size = H5Fget_name(static_cast<hid_t>(*this),NULL,0);
+  ssize_t size = H5Fget_name(static_cast<hid_t>(*this), NULL, 0);
 
-  if(size<0)
+  if (size < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure to determine file name length!");
   }
 
-  std::vector<char> buffer(size+1);
-  if(H5Fget_name(static_cast<hid_t>(*this),buffer.data(),size+1)<0)
+  std::vector<char> buffer(size + 1);
+  if (H5Fget_name(static_cast<hid_t>(*this), buffer.data(), size + 1) < 0)
   {
     std::stringstream ss;
-    ss<<"Error retrieving file name of size "<<size<<" for HDF5 file!";
+    ss << "Error retrieving file name of size " << size << " for HDF5 file!";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
 
-  return boost::filesystem::path(std::string(buffer.begin(),--buffer.end()));
+  return boost::filesystem::path(std::string(buffer.begin(), --buffer.end()));
 }
 
 size_t File::count_open_objects(SearchFlagsBase flags) const
 {
   ssize_t nobjects = 0;
-  nobjects=  H5Fget_obj_count(static_cast<hid_t>(*this),flags);
-  if(nobjects<0)
+  nobjects = H5Fget_obj_count(static_cast<hid_t>(*this), flags);
+  if (nobjects < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure retrieving the open object count for this file!");
   }
@@ -112,12 +113,12 @@ class node::Group File::root(const property::GroupAccessList &gapl) const
 {
   try
   {
-    ObjectHandle handle(H5Gopen(static_cast<hid_t>(*this),"/",static_cast<hid_t>(gapl)));
-    node::Link root_link(*this,Path("/"),"/");
+    ObjectHandle handle(H5Gopen(static_cast<hid_t>(*this), "/", static_cast<hid_t>(gapl)));
+    node::Link root_link(*this, Path("/"), "/");
 
-    return node::Group(node::Node(std::move(handle),root_link));
+    return node::Group(node::Node(std::move(handle), root_link));
   }
-  catch(...)
+  catch (...)
   {
     std::throw_with_nested(std::runtime_error("Error obtaining root group from file!"));
   }
@@ -135,12 +136,12 @@ ObjectId File::id() const
   {
     valid = is_valid();
   }
-  catch(...)
+  catch (...)
   {
     std::throw_with_nested(std::runtime_error("Cannot obtain ObjectId from an invalid file instance!"));
   }
 
-  if(!valid)
+  if (!valid)
   {
     error::Singleton::instance().throw_with_stack("Cannot obtain ObjectId from an invalid file instance!");
   }

--- a/src/h5cpp/file/file.hpp
+++ b/src/h5cpp/file/file.hpp
@@ -42,125 +42,124 @@ namespace file {
 
 class DLL_EXPORT File
 {
-  public:
-    //!
-    //! \brief default constructor
-    //!
-    //! Use default implementation here. We need this to store instances of
-    //! this class in an STL container. A default constructed instance of File
-    //! is in an invalid state. This can be checked using the is_valid()
-    //! method.
-    //!
-    //! \sa is_valid()
-    //!
-    File()             = default;
+ public:
+  //!
+  //! \brief default constructor
+  //!
+  //! Use default implementation here. We need this to store instances of
+  //! this class in an STL container. A default constructed instance of File
+  //! is in an invalid state. This can be checked using the is_valid()
+  //! method.
+  //!
+  //! \sa is_valid()
+  //!
+  File() = default;
 
-    //!
-    //! \brief copy constructor
-    //!
-    //! Use default implementation here.
-    //!
-    File(const File &) = default;
+  //!
+  //! \brief copy constructor
+  //!
+  //! Use default implementation here.
+  //!
+  File(const File &) = default;
 
-    //!
-    //! \brief move constructor
-    //!
-    //! Use default implementation here.
-    //!
-    File(File &&)      = default;
+  //!
+  //! \brief move constructor
+  //!
+  //! Use default implementation here.
+  //!
+  File(File &&) = default;
 
-    //!
-    //! \brief constructor
-    //!
-    //! Construct a file from an rvalue reference to a handle.
-    //!
-    //! \param handle rvalue reference to the file handler
-    //!
-    explicit File(ObjectHandle &&handle);
+  //!
+  //! \brief constructor
+  //!
+  //! Construct a file from an rvalue reference to a handle.
+  //!
+  //! \param handle rvalue reference to the file handler
+  //!
+  explicit File(ObjectHandle &&handle);
 
-    File &operator=(const File&) = default;
+  File &operator=(const File &) = default;
 
-    //!
-    //! \brief get access flags for the file
-    //!
-    //! \throws std::runtime_error in case of a failure
-    //!
-    AccessFlags intent() const;
+  //!
+  //! \brief get access flags for the file
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  AccessFlags intent() const;
 
-    //!
-    //! \brief get the file size in bytes
-    //!
-    //! \throws std::runtime_error in case of a failure
-    //!
-    size_t size() const;
+  //!
+  //! \brief get the file size in bytes
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  size_t size() const;
 
-    //!
-    //! \brief flush the file
-    //!
-    //! \throws std::runtime_error in case of a failure
-    //! \param scope the scope within which the file should be flushed
-    //!
-    void flush(Scope scope) const;
+  //!
+  //! \brief flush the file
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //! \param scope the scope within which the file should be flushed
+  //!
+  void flush(Scope scope) const;
 
-    //!
-    //! \brief close the file
-    //!
-    //! \throws std::runtime_error in case of a failure
-    //!
-    void close();
+  //!
+  //! \brief close the file
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  void close();
 
-    //!
-    //! \brief get path on file system
-    //!
-    //! Return the file system path of the file.
-    //!
-    boost::filesystem::path path() const;
+  //!
+  //! \brief get path on file system
+  //!
+  //! Return the file system path of the file.
+  //!
+  boost::filesystem::path path() const;
 
-    //!
-    //! \brief count number of open objects
-    //!
-    //! Return the number of open objects belonging to that very file instance.
-    //!
-    size_t count_open_objects(SearchFlags flag) const;
-    size_t count_open_objects(SearchFlagsBase flags) const;
+  //!
+  //! \brief count number of open objects
+  //!
+  //! Return the number of open objects belonging to that very file instance.
+  //!
+  size_t count_open_objects(SearchFlags flag) const;
+  size_t count_open_objects(SearchFlagsBase flags) const;
 
-    //!
-    //! \brief get root group
-    //!
-    //! Return an instance to the root group of the file.
-    //!
-    //! \throws std::runtime_error in case of a failure
-    //!
-    //! \param gapl reference to a group access property list
-    //! \return new instance of node::Group
-    //!
-    node::Group root(const property::GroupAccessList &gapl = property::GroupAccessList()) const;
+  //!
+  //! \brief get root group
+  //!
+  //! Return an instance to the root group of the file.
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  //! \param gapl reference to a group access property list
+  //! \return new instance of node::Group
+  //!
+  node::Group root(const property::GroupAccessList &gapl = property::GroupAccessList()) const;
 
-    explicit operator hid_t() const
-    {
-      return static_cast<hid_t>(handle_);
-    }
+  explicit operator hid_t() const
+  {
+    return static_cast<hid_t>(handle_);
+  }
 
-    //!
-    //! \brief check validity of the instance
-    //!
-    //! Return true if the instance refers to a valid HDF5 file instance.
-    //!
-    //! \throw std::runtime_error in case of a failure
-    //!
-    //! \return true if valid, false otherwise
-    bool is_valid() const;
+  //!
+  //! \brief check validity of the instance
+  //!
+  //! Return true if the instance refers to a valid HDF5 file instance.
+  //!
+  //! \throw std::runtime_error in case of a failure
+  //!
+  //! \return true if valid, false otherwise
+  bool is_valid() const;
 
-    //!
-    //! \brief return a unique id for the file object
-    //!
-    //! Return an instance of ObjectId which uniquely identifies a file object.
-    //!
-    ObjectId id() const;
+  //!
+  //! \brief return a unique id for the file object
+  //!
+  //! Return an instance of ObjectId which uniquely identifies a file object.
+  //!
+  ObjectId id() const;
 
-
-  private:
-    ObjectHandle handle_; //!< handle for the file object
+ private:
+  ObjectHandle handle_; //!< handle for the file object
 
 };
 

--- a/src/h5cpp/file/functions.cpp
+++ b/src/h5cpp/file/functions.cpp
@@ -19,7 +19,7 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors: Eugen Wintersberger <eugen.wintersberger@desy.de>
 // Author: Martin Shetty <martin.shetty@esss.se>
 // Created on: Sep 9, 2017
 //
@@ -41,16 +41,15 @@ File create(const boost::filesystem::path &path, AccessFlagsBase flags,
 {
   hid_t fid = H5Fcreate(path.string().c_str(), flags,
                         static_cast<hid_t>(fcpl), static_cast<hid_t>(fapl));
-  if(fid<0)
+  if (fid < 0)
   {
     std::stringstream ss;
-    ss<<"Failure creating file ["<<path<<"]";
+    ss << "Failure creating file [" << path << "]";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
 
   return File(hdf5::ObjectHandle(fid));
 }
-
 
 File open(const boost::filesystem::path &path, AccessFlags flags,
           const property::FileAccessList &fapl)
@@ -58,32 +57,29 @@ File open(const boost::filesystem::path &path, AccessFlags flags,
   return open(path, static_cast<AccessFlagsBase>(flags), fapl);
 }
 
-//TODO: needs better error handling, throw something
 File open(const boost::filesystem::path &path, AccessFlagsBase flags,
           const property::FileAccessList &fapl)
 {
-  return File(ObjectHandle(
-      H5Fopen(path.string().c_str(), flags, static_cast<hid_t>(fapl))
-  ));
+  hid_t fid = H5Fopen(path.string().c_str(), flags, static_cast<hid_t>(fapl));
+  if (fid < 0)
+  {
+    std::stringstream ss;
+    ss << "Failure opening file [" << path << "]";
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+  return File(ObjectHandle(fid));
 }
 
 bool is_hdf5_file(const boost::filesystem::path &path)
 {
   htri_t result = H5Fis_hdf5(path.string().c_str());
-  if(result>0)
-  {
-    return true;
-  }
-  else if(result==0)
-  {
-    return false;
-  }
-  else
+  if (result < 0)
   {
     std::stringstream ss;
-    ss<<"Failure to determine whether "<<path.string()<<"is an HDF5 file or not!";
+    ss << "Failure to determine whether " << path.string() << "is an HDF5 file or not!";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
+  return (result != 0);
 }
 
 } // namespace file

--- a/src/h5cpp/file/memory_driver.cpp
+++ b/src/h5cpp/file/memory_driver.cpp
@@ -32,21 +32,17 @@ namespace hdf5 {
 namespace file {
 
 MemoryDriver::MemoryDriver() noexcept:
-    increment_(1024*1024),
-    backing_store_(false)
-{}
+    increment_(1024 * 1024),
+    backing_store_(false) {}
 
-
-MemoryDriver::MemoryDriver(size_t increment,bool backing_store) noexcept:
+MemoryDriver::MemoryDriver(size_t increment, bool backing_store) noexcept:
     increment_(increment),
-    backing_store_(backing_store)
-{}
+    backing_store_(backing_store) {}
 
 bool MemoryDriver::backing_store() const noexcept
 {
   return backing_store_;
 }
-
 
 void MemoryDriver::backing_store(bool value) noexcept
 {
@@ -65,7 +61,7 @@ void MemoryDriver::increment(size_t value)
 
 void MemoryDriver::operator()(const property::FileAccessList &fapl) const
 {
-  if(H5Pset_fapl_core(static_cast<hid_t>(fapl),increment_,backing_store_)<0)
+  if (H5Pset_fapl_core(static_cast<hid_t>(fapl), increment_, backing_store_) < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure setting Core driver!");
   }
@@ -75,7 +71,6 @@ DriverID MemoryDriver::id() const noexcept
 {
   return DriverID::MEMORY;
 }
-
 
 }
 }

--- a/src/h5cpp/file/posix_driver.cpp
+++ b/src/h5cpp/file/posix_driver.cpp
@@ -30,12 +30,11 @@
 namespace hdf5 {
 namespace file {
 
-PosixDriver::PosixDriver()
-{}
+PosixDriver::PosixDriver() {}
 
 void PosixDriver::operator()(const property::FileAccessList &fapl) const
 {
-  if(H5Pset_fapl_sec2(static_cast<hid_t>(fapl))<0)
+  if (H5Pset_fapl_sec2(static_cast<hid_t>(fapl)) < 0)
   {
     error::Singleton::instance().throw_with_stack("Failure setting up POSIX driver!");
   }

--- a/src/h5cpp/property/dataset_transfer.cpp
+++ b/src/h5cpp/property/dataset_transfer.cpp
@@ -1,4 +1,4 @@
-//
+
 // (c) Copyright 2017 DESY,ESS
 //
 // This file is part of h5cpp.
@@ -117,9 +117,10 @@ void DatasetTransferList::mpi_chunk_option(MPIChunkOption option) const
   }
 }
 
+// TODO implement this properly
 MPIChunkOption DatasetTransferList::mpi_chunk_option() const
 {
-
+  throw std::runtime_error("DatasetTransferList::mpi_chunk_option() is not implemented in h5cpp!");
 }
 
 

--- a/test/file/CMakeLists.txt
+++ b/test/file/CMakeLists.txt
@@ -5,7 +5,9 @@ set(test_sources
   ${dir}/searchflags_test.cpp
   ${dir}/accessflags_test.cpp
   ${dir}/scope_test.cpp
+  ${dir}/file_test.cpp
   ${dir}/file_creation_test.cpp
   ${dir}/file_open_test.cpp
   ${dir}/is_hdf5_test.cpp
+  ${dir}/driver_test.cpp
   PARENT_SCOPE)

--- a/test/file/driver_test.cpp
+++ b/test/file/driver_test.cpp
@@ -1,0 +1,114 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Author: Martin Shetty <martin.shetty@esss.se>
+// Created on: May 4, 2018
+//
+
+#include <gtest/gtest.h>
+#include <h5cpp/file/functions.hpp>
+#include <h5cpp/node/group.hpp>
+#include <h5cpp/hdf5.hpp>
+
+using namespace hdf5;
+namespace fs = boost::filesystem;
+
+TEST(MemoryDriver, create_default)
+{
+  file::MemoryDriver m;
+  EXPECT_EQ(m.id(), file::DriverID::MEMORY);
+}
+
+TEST(MemoryDriver, create_custom)
+{
+  file::MemoryDriver m(7000, true);
+  EXPECT_TRUE(m.backing_store());
+  EXPECT_EQ(m.increment(), 7000);
+}
+
+TEST(MemoryDriver, backing_store)
+{
+  file::MemoryDriver m;
+  EXPECT_FALSE(m.backing_store());
+  m.backing_store(true);
+  EXPECT_TRUE(m.backing_store());
+}
+
+TEST(MemoryDriver, increment)
+{
+  file::MemoryDriver m;
+  EXPECT_EQ(m.increment(), 1024 * 1024);
+  m.increment(5000);
+  EXPECT_EQ(m.increment(), 5000);
+}
+
+TEST(MemoryDriver, apply)
+{
+  property::FileCreationList fcpl;
+  property::FileAccessList fapl;
+  file::MemoryDriver m(7000, true);
+  m(fapl);
+  file::create("memory_file.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
+
+  ObjectHandle(static_cast<hid_t>(fapl)).close();
+  EXPECT_THROW(m(fapl), std::runtime_error);
+}
+
+
+TEST(PosixDriver, create_default)
+{
+  file::PosixDriver m;
+  EXPECT_EQ(m.id(), file::DriverID::POSIX);
+}
+
+TEST(PosixDriver, apply)
+{
+  property::FileCreationList fcpl;
+  property::FileAccessList fapl;
+  file::PosixDriver m;
+  m(fapl);
+  file::create("posix_file.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
+
+  ObjectHandle(static_cast<hid_t>(fapl)).close();
+  EXPECT_THROW(m(fapl), std::runtime_error);
+}
+
+#ifdef WITH_MPI
+
+TEST(MPIDriver, create_default)
+{
+  file::MPIDriver m(MPI_COMM_WORLD,MPI_INFO_NULL);
+  EXPECT_EQ(m.id(), file::DriverID::MPI);
+}
+
+TEST(MPIDriver, apply)
+{
+  property::FileCreationList fcpl;
+  property::FileAccessList fapl;
+  file::MPIDriver m(MPI_COMM_WORLD,MPI_INFO_NULL);
+  m(fapl);
+  file::create("posix_file.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
+
+  ObjectHandle(static_cast<hid_t>(fapl)).close();
+  EXPECT_THROW(m(fapl), std::runtime_error);
+}
+
+#endif

--- a/test/file/file_open_test.cpp
+++ b/test/file/file_open_test.cpp
@@ -31,50 +31,53 @@ namespace fs = boost::filesystem;
 
 class FileOpen : public testing::Test
 {
-  protected:
-    virtual void SetUp()
-    {
-#if H5_VERSION_GE(1,10,0)
-      property::FileCreationList fcpl;
-      property::FileAccessList fapl;
-      fapl.library_version_bounds(property::LibVersion::LATEST,
-                                  property::LibVersion::LATEST);
-      file::create("file_open.h5", file::AccessFlags::TRUNCATE,fcpl,fapl);
+ protected:
+  virtual void SetUp()
+  {
+#if H5_VERSION_GE(1, 10, 0)
+    property::FileCreationList fcpl;
+    property::FileAccessList fapl;
+    fapl.library_version_bounds(property::LibVersion::LATEST,
+                                property::LibVersion::LATEST);
+    file::create("file_open.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
 #else
-      file::create("file_open.h5", file::AccessFlags::TRUNCATE);
+    file::create("file_open.h5", file::AccessFlags::TRUNCATE);
 #endif
-    }
+  }
 };
-
 
 TEST_F(FileOpen, test_open_default)
 {
   file::File f = file::open("file_open.h5");
-  EXPECT_EQ(f.intent(),file::AccessFlags::READONLY);
+  EXPECT_EQ(f.intent(), file::AccessFlags::READONLY);
 }
 
 TEST_F(FileOpen, test_open_readwrite)
 {
-  file::File f = file::open("file_open.h5",file::AccessFlags::READWRITE);
-  EXPECT_EQ(f.intent(),file::AccessFlags::READWRITE);
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_EQ(f.intent(), file::AccessFlags::READWRITE);
 }
 
-#if H5_VERSION_GE(1,10,0)
+TEST_F(FileOpen, test_open_nonexistent)
+{
+  EXPECT_THROW(file::open("nonexistent.qqq", file::AccessFlags::READWRITE), std::runtime_error);
+}
+
+#if H5_VERSION_GE(1, 10, 0)
 
 TEST_F(FileOpen, test_open_swmr_read)
 {
-  file::File f = file::open("file_open.h5",file::AccessFlags::SWMR_READ);
-  EXPECT_EQ(f.intent(),file::AccessFlags::SWMR_READ);
+  file::File f = file::open("file_open.h5", file::AccessFlags::SWMR_READ);
+  EXPECT_EQ(f.intent(), file::AccessFlags::SWMR_READ);
 }
 
 TEST_F(FileOpen, test_open_swmr_write)
 {
   file::File f = file::open("file_open.h5",
-                             file::AccessFlags::READWRITE | file::AccessFlags::SWMR_WRITE);
-
+                            file::AccessFlags::READWRITE | file::AccessFlags::SWMR_WRITE);
 
   EXPECT_EQ(static_cast<file::AccessFlagsBase>(f.intent()),
-                    file::AccessFlags::SWMR_WRITE|file::AccessFlags::READWRITE  );
+            file::AccessFlags::SWMR_WRITE | file::AccessFlags::READWRITE);
 
 }
 

--- a/test/file/file_test.cpp
+++ b/test/file/file_test.cpp
@@ -1,0 +1,125 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Author: Martin Shetty <martin.shetty@esss.se>
+// Created on: May 4, 2018
+//
+
+#include <gtest/gtest.h>
+#include <h5cpp/file/functions.hpp>
+#include <h5cpp/node/group.hpp>
+
+using namespace hdf5;
+namespace fs = boost::filesystem;
+
+class File : public testing::Test
+{
+ protected:
+  virtual void SetUp()
+  {
+#if H5_VERSION_GE(1, 10, 0)
+    property::FileCreationList fcpl;
+    property::FileAccessList fapl;
+    fapl.library_version_bounds(property::LibVersion::LATEST,
+                                property::LibVersion::LATEST);
+    file::create("file_open.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
+#else
+    file::create("file_open.h5", file::AccessFlags::TRUNCATE);
+#endif
+  }
+};
+
+TEST_F(File, is_valid)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_TRUE(f.is_valid());
+}
+
+TEST_F(File, close)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  f.close();
+  EXPECT_FALSE(f.is_valid());
+}
+
+TEST_F(File, intent)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_EQ(f.intent(), file::AccessFlags::READWRITE);
+
+  f.close();
+  EXPECT_THROW(f.intent(), std::runtime_error);
+}
+
+TEST_F(File, size)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_GE(f.size(), 0);
+
+  f.close();
+  EXPECT_THROW(f.size(), std::runtime_error);
+}
+
+TEST_F(File, id)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_EQ(f.id().file_name(), "file_open.h5");
+
+  f.close();
+  EXPECT_THROW(f.id(), std::runtime_error);
+}
+
+TEST_F(File, path)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_EQ(f.path().string(), "file_open.h5");
+
+  f.close();
+  EXPECT_THROW(f.path(), std::runtime_error);
+}
+
+TEST_F(File, root)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_EQ(f.root().link().path(), "/");
+
+  f.close();
+  EXPECT_THROW(f.root(), std::runtime_error);
+}
+
+TEST_F(File, count_open_objects)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  auto r = f.root();
+  EXPECT_EQ(f.count_open_objects(file::SearchFlags::GROUP), 1);
+
+  f.close();
+  EXPECT_THROW(f.count_open_objects(file::SearchFlags::ALL), std::runtime_error);
+}
+
+TEST_F(File, flush)
+{
+  file::File f = file::open("file_open.h5", file::AccessFlags::READWRITE);
+  EXPECT_NO_THROW(f.flush(file::Scope::GLOBAL));
+
+  f.close();
+  EXPECT_THROW(f.flush(file::Scope::GLOBAL), std::runtime_error);
+}

--- a/test/file/is_hdf5_test.cpp
+++ b/test/file/is_hdf5_test.cpp
@@ -32,25 +32,24 @@ namespace fs = boost::filesystem;
 
 class IsHDF5 : public testing::Test
 {
-  protected:
-    IsHDF5() {}
-    virtual void SetUp()
-    {
-      std::ofstream ofile("test.txt");
-      ofile<<"hello world"<<std::endl;
-      ofile.close();
+ protected:
+  IsHDF5() {}
+  virtual void SetUp()
+  {
+    std::ofstream ofile("test.txt");
+    ofile << "hello world" << std::endl;
+    ofile.close();
 
-      file::create("test.h5", file::AccessFlags::TRUNCATE);
-    }
+    file::create("test.h5", file::AccessFlags::TRUNCATE);
+  }
 
-    virtual void TearDown()
-    {
-      fs::remove("test.txt");
-      fs::remove("test.h5");
-    }
-    virtual ~IsHDF5() {}
+  virtual void TearDown()
+  {
+    fs::remove("test.txt");
+    fs::remove("test.h5");
+  }
+  virtual ~IsHDF5() {}
 };
-
 
 TEST_F(IsHDF5, test_hdf5_file)
 {
@@ -62,6 +61,10 @@ TEST_F(IsHDF5, test_no_hdf5_file)
   EXPECT_FALSE(file::is_hdf5_file("test.txt"));
 }
 
+TEST_F(IsHDF5, test_failure)
+{
+  EXPECT_THROW(file::is_hdf5_file("nonexistent.qqq"), std::runtime_error);
+}
 
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -27,6 +27,10 @@
 
 int main(int argc, char **argv)
 {
+#ifdef WITH_MPI
+  MPI_Init(&argc,&argv);
+#endif
+
   hdf5::error::Singleton::instance().auto_print(false);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/property/dataset_transfer_test.cpp
+++ b/test/property/dataset_transfer_test.cpp
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 #include <h5cpp/property/dataset_transfer.hpp>
 #include <h5cpp/property/property_class.hpp>
+#include <sstream>
 
 namespace pl = hdf5::property;
 
@@ -54,5 +55,51 @@ TEST(DatasetTransferList,test_as_default_argument)
   EXPECT_NO_THROW(test_function());
 }
 
-// Missing MPI-related functions tests here
+#ifdef WITH_MPI
 
+TEST(DatasetTransferList, flags)
+{
+  std::stringstream stream;
+
+  stream << pl::MPITransferMode::INDEPENDENT;
+  EXPECT_EQ(stream.str(), "INDEPENDENT");
+
+  stream.str(std::string());
+  stream << pl::MPITransferMode::COLLECTIVE;
+  EXPECT_EQ(stream.str(), "COLLECTIVE");
+
+  stream.str(std::string());
+  stream << pl::MPIChunkOption::ONE_LINK_CHUNKED;
+  EXPECT_EQ(stream.str(), "ONE_LINK_CHUNKED");
+
+  stream.str(std::string());
+  stream << pl::MPIChunkOption::MULTI_CHUNK;
+  EXPECT_EQ(stream.str(), "MULTI_CHUNK");
+}
+
+TEST(DatasetTransferList, transfer_mode)
+{
+  pl::DatasetTransferList dtpl;
+  dtpl.mpi_transfer_mode(pl::MPITransferMode::INDEPENDENT);
+  EXPECT_EQ(dtpl.mpi_transfer_mode(), pl::MPITransferMode::INDEPENDENT);
+
+  dtpl.mpi_transfer_mode(pl::MPITransferMode::COLLECTIVE);
+  EXPECT_EQ(dtpl.mpi_transfer_mode(), pl::MPITransferMode::COLLECTIVE);
+
+  hdf5::ObjectHandle(static_cast<hid_t>(dtpl)).close();
+  EXPECT_THROW(dtpl.mpi_transfer_mode(pl::MPITransferMode::COLLECTIVE), std::runtime_error);
+  EXPECT_THROW(dtpl.mpi_transfer_mode(), std::runtime_error);
+}
+
+TEST(DatasetTransferList, chunk_option)
+{
+  pl::DatasetTransferList dtpl;
+  dtpl.mpi_chunk_option(pl::MPIChunkOption::ONE_LINK_CHUNKED);
+  dtpl.mpi_chunk_option(pl::MPIChunkOption::MULTI_CHUNK);
+
+  EXPECT_THROW(dtpl.mpi_chunk_option(), std::runtime_error);
+  hdf5::ObjectHandle(static_cast<hid_t>(dtpl)).close();
+  EXPECT_THROW(dtpl.mpi_chunk_option(pl::MPIChunkOption::MULTI_CHUNK), std::runtime_error);
+}
+
+#endif


### PR DESCRIPTION
Test coverage for File classes, including Drivers and MPI-related code in the driver classes and in Dataset Transfer Proplists.
Jenkinsfile now builds on Docker images that support MPI, particularly the tests and coverage reports are run on one of these.