### PR TITLE
changed signature for create_dataset; updates #283'

### DIFF
--- a/src/h5cpp/node/group.cpp
+++ b/src/h5cpp/node/group.cpp
@@ -123,8 +123,8 @@ Group Group::create_group(const std::string &name,
 Dataset Group::create_dataset(const std::string &name,
                               const datatype::Datatype &type,
                               const dataspace::Dataspace &space,
-                              const property::LinkCreationList &lcpl,
                               const property::DatasetCreationList &dcpl,
+                              const property::LinkCreationList &lcpl,
                               const property::DatasetAccessList &dapl) const
 {
   if(!Path(name).is_name())

--- a/src/h5cpp/node/group.hpp
+++ b/src/h5cpp/node/group.hpp
@@ -139,14 +139,14 @@ class DLL_EXPORT Group : public Node
     //!
     //! \brief create a new dataset
     //!
-    //! Like for groups the
     Dataset create_dataset(const std::string &name,
                            const datatype::Datatype &type,
                            const dataspace::Dataspace &space,
-                           const property::LinkCreationList &lcpl = property::LinkCreationList(),
                            const property::DatasetCreationList &dcpl = property::DatasetCreationList(),
+                           const property::LinkCreationList &lcpl = property::LinkCreationList(),
                            const property::DatasetAccessList &dapl = property::DatasetAccessList()
                            ) const;
+
 
     //!
     //! \brief get node


### PR DESCRIPTION
It appears that it does not get used anywhere in the tests, possibly only in our programs that use it as a dependency. I think this ordering of parameters makes more sense, so all that remains is to refactor our code when we switch the package.