### PR TITLE
error classes improved, tests for error classes improved; updates #234'

### DIFF
--- a/src/h5cpp/error/descriptor.cpp
+++ b/src/h5cpp/error/descriptor.cpp
@@ -34,43 +34,43 @@ extern "C"{
 namespace hdf5 {
 namespace error {
 
+// can't throw here (HDF5 C implementation disallows it)
 Descriptor::Descriptor(const H5E_error2_t& descr)
 {
   line = descr.line;
-  file = std::string(descr.file_name, strlen(descr.file_name));
-  function = std::string(descr.func_name, strlen(descr.func_name));
-  description = std::string(descr.desc, strlen(descr.desc));
 
+  maj_num = descr.maj_num;
+  min_num = descr.min_num;
+
+  if (descr.file_name && (strlen(descr.file_name) > 0))
+    file = std::string(descr.file_name, strlen(descr.file_name));
+  if (descr.func_name && (strlen(descr.func_name) > 0))
+    function = std::string(descr.func_name, strlen(descr.func_name));
+  if (descr.desc && (strlen(descr.desc) > 0))
+    description = std::string(descr.desc, strlen(descr.desc));
+}
+
+// could throw here, but probably shouldn't
+void Descriptor::extract_strings()
+{
   H5E_type_t message_type;
   ssize_t    message_size = 0;
 
-  //
   // retrieve the major error message
-  //
-  message_size = H5Eget_msg(descr.maj_num,&message_type,NULL,0);
-  if(message_size<0)
-  {
-    throw std::runtime_error("Failure to obtain major error message!");
-  }
+  message_size = H5Eget_msg(maj_num,&message_type,NULL,0);
   if(message_size > 0 && message_type == H5E_MAJOR)
   {
     std::vector<char> message_buffer(message_size+1);
-    H5Eget_msg(descr.maj_num,&message_type,message_buffer.data(),message_size+1);
+    H5Eget_msg(maj_num,&message_type,message_buffer.data(),message_size+1);
     major = std::string(message_buffer.begin(),--message_buffer.end());
   }
 
-  //
   // retrieve the minor error message
-  //
-  message_size = H5Eget_msg(descr.min_num,&message_type,NULL,0);
-  if(message_size < 0)
-  {
-    throw std::runtime_error("Failure to obtain minor error message!");
-  }
+  message_size = H5Eget_msg(min_num,&message_type,NULL,0);
   if(message_size > 0 && message_type == H5E_MINOR)
   {
     std::vector<char> message_buffer(message_size+1);
-    H5Eget_msg(descr.min_num,&message_type,message_buffer.data(),message_size+1);
+    H5Eget_msg(min_num,&message_type,message_buffer.data(),message_size+1);
     minor = std::string(message_buffer.begin(),--message_buffer.end());
   }
 }

--- a/src/h5cpp/error/descriptor.hpp
+++ b/src/h5cpp/error/descriptor.hpp
@@ -29,8 +29,10 @@
 #include <iostream>
 #include <string>
 
-namespace hdf5 {
-namespace error {
+namespace hdf5
+{
+namespace error
+{
 
 //!
 //! \brief HDF5 error descriptor
@@ -41,32 +43,35 @@ namespace error {
 //! of the library along with thrown exceptions, but only in the case
 //! that automatic error stack printing is turned off.
 //!
-struct DLL_EXPORT  Descriptor {
-
+struct DLL_EXPORT Descriptor
+{
   //!
   //! \brief constructor
   //!
-  //! Constructs a mostly human-readable constructor from the underlying
+  //! Constructs a mostly human-readable descriptor from the underlying
   //! C-API handle. Only used by the library internally.
   //!
   //! \param descr reference to C-API error entry
   //!
   Descriptor(const H5E_error2_t& descr);
 
-  std::string   major;         // major error text
-  std::string   minor;         // minor error text
+  void extract_strings();
 
-  unsigned      line;          // line in file where error occurs
-  std::string   function;      // function in which error occurred
-  std::string   file;          // file in which error occurred
-  std::string   description;   // supplied description
+  hid_t       maj_num;	// major error ID
+  hid_t       min_num;	// minor error number
+  std::string major;         // major error text
+  std::string minor;         // minor error text
+
+  unsigned line;          // line in file where error occurs
+  std::string function;      // function in which error occurred
+  std::string file;          // file in which error occurred
+  std::string description;   // supplied description
 };
 
 //!
 //! \brief output operator for Descriptor
 //!
-DLL_EXPORT std::ostream &operator<<(std::ostream &stream, const Descriptor &desc);
-
+DLL_EXPORT std::ostream& operator<<(std::ostream& stream, const Descriptor& desc);
 
 } // namespace file
 } // namespace hdf5

--- a/src/h5cpp/error/error.cpp
+++ b/src/h5cpp/error/error.cpp
@@ -63,7 +63,6 @@ H5CError Singleton::extract_stack()
     throw std::runtime_error("Could not extract error stack");
   }
 
-  clear_stack();
   return H5CError(ret);
 }
 
@@ -120,7 +119,7 @@ void Singleton::clear_stack()
   herr_t ret = H5Eclear2(H5E_DEFAULT);
   if (0 > ret)
   {
-    throw std::runtime_error("Could not toggle automatic error stack printing");
+    throw std::runtime_error("Could not clear HDF5 error stack");
   }
 }
 

--- a/src/h5cpp/error/error.hpp
+++ b/src/h5cpp/error/error.hpp
@@ -89,6 +89,11 @@ class DLL_EXPORT Singleton
   //!
   void throw_with_stack(const std::string& message);
 
+  //!
+  //! \brief clears HDF5 error stack
+  //!
+  void clear_stack();
+
  private:
 
   // Singleton assurance
@@ -101,16 +106,13 @@ class DLL_EXPORT Singleton
  private:
   // Helper functions, used internally only
 
-  // determines if automatic printing is anebled
+  // determines if automatic printing is enabled
   // should never be used when extracting error information,
   // as it will overwirte existing error stack contents
   bool auto_print_enabled() const;
 
-  // extracts error stack and throws it as Stcak
+  // extracts error stack and throws it as H5CError
   void throw_stack();
-
-  // clears error stack
-  void clear_stack();
 
   // functor for H5EWalk
   static herr_t to_list(unsigned n,

--- a/src/h5cpp/error/h5c_error.cpp
+++ b/src/h5cpp/error/h5c_error.cpp
@@ -34,8 +34,11 @@ H5CError::H5CError(const std::list<Descriptor>& H5CError)
 , contents_(H5CError)
 {
   std::stringstream ss;
-  for (auto c : contents_)
+  for (auto& c : contents_)
+  {
+    c.extract_strings();
     ss << c << "\n";
+  }
   what_message_ = ss.str();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,15 +16,17 @@ configure_file(h5py_test_data.h5 h5py_test_data.h5 COPYONLY)
 
 set(dir ${CMAKE_CURRENT_SOURCE_DIR})
 
+set(test_sources ${dir}/main.cpp)
+set(test_headers ${dir}/h5cpp_test_helpers.hpp)
+
 set(test_sources
-  ${dir}/main.cpp
-  ${dir}/fixture.cpp
-  )
+    ${test_sources}
+    ${dir}/fixture.cpp)
 
 set(test_headers
-  ${dir}/fixture.hpp
-  )
-
+    ${test_headers}
+    ${dir}/fixture.hpp
+    )
 add_subdirectory(error)
 add_subdirectory(core)
 add_subdirectory(property)

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(dir ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(test_sources
-  ${test_sources}
-  ${dir}/error_test.cpp
-  PARENT_SCOPE)
+    ${test_sources}
+    ${dir}/descriptor_test.cpp
+    ${dir}/h5c_error_test.cpp
+    ${dir}/error_test.cpp
+    PARENT_SCOPE)

--- a/test/error/descriptor_test.cpp
+++ b/test/error/descriptor_test.cpp
@@ -1,0 +1,82 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5pp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Author: Martin Shetty <martin.shetty@esss.se>
+// Created on: May 5, 2018
+//
+
+#include <gtest/gtest.h>
+#include "../h5cpp_test_helpers.hpp"
+
+using namespace hdf5;
+
+TEST(Descriptor, extract_data)
+{
+  provoke_h5_error();
+  auto stack = error::Singleton::instance().extract_stack();
+  EXPECT_GT(stack.contents().size(), 0);
+  auto d = stack.contents().front();
+
+  EXPECT_GT(d.line, 10);
+  EXPECT_EQ(d.function, "H5Iget_ref");
+  EXPECT_NE(d.file.find("H5I.c"), std::string::npos);
+  EXPECT_EQ(d.description, "can't get ID ref count");
+}
+
+TEST(Descriptor, extract_strings)
+{
+  provoke_h5_error();
+  auto stack = error::Singleton::instance().extract_stack();
+  EXPECT_GT(stack.contents().size(), 0);
+  auto d = stack.contents().front();
+
+  d.extract_strings();
+  EXPECT_EQ(d.major, "Object atom");
+  EXPECT_EQ(d.minor, "Can't get value");
+}
+
+TEST(Descriptor, stream)
+{
+  hdf5::ObjectHandle invalid_handle;
+  H5Iget_ref(static_cast<hid_t>(invalid_handle));
+  auto d = error::Singleton::instance().extract_stack().contents().front();
+
+  std::stringstream ss;
+  ss << d;
+  EXPECT_NE(ss.str().find(d.description), std::string::npos);
+}
+
+// To ensure no-throw, C-string pointers must be null-initialized
+// Talk to HDF5 group to see if they could make this happen
+TEST(Descriptor, illegal)
+{
+  H5E_error2_t descr;
+  descr.file_name = nullptr;
+  descr.func_name = nullptr;
+  descr.desc = nullptr;
+  EXPECT_NO_THROW(error::Descriptor f(descr));
+  error::Descriptor f(descr);
+
+  // This also generates errors on the error stack!!! Insane!
+  EXPECT_NO_THROW(f.extract_strings());
+
+  error::Singleton::instance().clear_stack();
+}

--- a/test/h5cpp_test_helpers.hpp
+++ b/test/h5cpp_test_helpers.hpp
@@ -20,37 +20,24 @@
 // ===========================================================================
 //
 // Author: Martin Shetty <martin.shetty@esss.se>
-// Created on: Nov 22, 2017
+// Created on: May 5, 2018
 //
 
 #pragma  once
 
-#include <gtest/gtest.h>
+#include <h5cpp/core/object_handle.hpp>
+#include <h5cpp/error/error.hpp>
 
-namespace testing
-{
-namespace internal
-{
-enum GTestColor {
-  COLOR_DEFAULT,
-  COLOR_RED,
-  COLOR_GREEN,
-  COLOR_YELLOW
-};
+#define INVALIDATE_HID(OBJ) hdf5::ObjectHandle(static_cast<hid_t>(OBJ)).close()
 
-extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+inline void provoke_h5_error()
+{
+  hdf5::ObjectHandle invalid_handle;
+  H5Iget_ref(static_cast<hid_t>(invalid_handle));
 }
-}
-#define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::COLOR_GREEN, "[          ] "); testing::internal::ColoredPrintf(testing::internal::COLOR_YELLOW, __VA_ARGS__); } while(0)
 
-// C++ stream interface
-class TestCout : public std::stringstream
+inline void provoke_h5cpp_exception()
 {
- public:
-  ~TestCout()
-  {
-    PRINTF("%s\n",str().c_str());
-  }
-};
-
-#define TEST_COUT  TestCout()
+  hdf5::ObjectHandle invalid_handle;
+  invalid_handle.get_reference_count();
+}


### PR DESCRIPTION
Better test coverage for the Error classes and, more importantly, some fundamental improvements.
There are problems to bring up with HDF group:
1) If `H5E_error2_t` could be made to initialize its C-string pointers as null. Would help avoid the problem of exceptions while in the error handling block. We do need to transfer those strings to `std::string`. I don't think that's unreasonable.
2) Getting messages for major and minor error numbers is itself prone to creating another error stack, in effect overwriting the existing one. This is as problem, because we do want to collect all the error information immediately, not at some later point. The way it is now is like shooting yourself in the foot.
3) No way to determine the state of the error auto-printing mechanism in the C-API without producing more errors, again overwriting the error stack. Every time we generate an exception based on the C-API error stack we need to check this state. If it didn't work like this, we could avoid using the singleton.