### PR TITLE
Bring in less boost

### DIFF
--- a/cmake/BoostLibraryConfig.cmake
+++ b/cmake/BoostLibraryConfig.cmake
@@ -8,3 +8,7 @@ find_package(Boost 1.41 COMPONENTS filesystem REQUIRED)
 if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
   add_definitions(-DBOOST_ALL_DYN_LINK)
 endif ()
+
+# Prevents requiring boost system,
+# may not be required when boost version >=1.67.0 is used
+add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)

--- a/conanfile_desi.txt
+++ b/conanfile_desi.txt
@@ -1,5 +1,6 @@
 [requires]
-Boost/1.62.0@lasote/stable
+cmake_findboost_modular/1.66.0@bincrafters/stable
+boost_filesystem/1.66.0@bincrafters/stable
 hdf5/1.10.1@eugenwintersberger/testing
 gtest/1.8.0@conan/stable
 zlib/1.2.8@conan/stable
@@ -9,10 +10,9 @@ bzip2/1.0.6@conan/stable
 cmake
 
 [options]
-Boost:shared=True
+boost_filesystem:shared=True
 hdf5:shared=True
 gtest:shared=True
-Boost:python=False
 zlib:shared=True
 
 [imports]

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -9,7 +9,7 @@ cmake
 virtualbuildenv
 
 [options]
-Boost:shared=True
+boost_filesystem:shared=True
 hdf5:shared=True
 hdf5:cxx=False
 gtest:shared=True

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -1,5 +1,6 @@
 [requires]
-Boost/1.62.0-dm1@ess-dmsc/stable
+cmake_findboost_modular/1.66.0@bincrafters/stable
+boost_filesystem/1.66.0@bincrafters/stable
 hdf5/1.10.2-dm2@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 

--- a/conanfile_ess_mpi.txt
+++ b/conanfile_ess_mpi.txt
@@ -1,5 +1,6 @@
 [requires]
-Boost/1.62.0@ess-dmsc/stable
+cmake_findboost_modular/1.66.0@bincrafters/stable
+boost_filesystem/1.66.0@bincrafters/stable
 hdf5/1.10.2-dm2@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 
@@ -8,7 +9,7 @@ cmake
 virtualbuildenv
 
 [options]
-Boost:shared=True
+boost_filesystem:shared=True
 hdf5:shared=True
 hdf5:cxx=False
 hdf5:parallel=True

--- a/src/h5cpp/core/path.cpp
+++ b/src/h5cpp/core/path.cpp
@@ -71,6 +71,7 @@ std::list<std::string> split_string(const std::string &to_split,
   std::string item;
   std::list<std::string> elems;
   while (std::getline(ss, item, delim)) {
+    // Don't create empty elements when the delimiter is repeated
     if (!item.empty())
       elems.push_back(std::move(item));
   }

--- a/src/h5cpp/core/path.cpp
+++ b/src/h5cpp/core/path.cpp
@@ -26,7 +26,7 @@
 //
 
 #include <h5cpp/core/path.hpp>
-#include <boost/algorithm/string.hpp>
+#include <sstream>
 
 namespace hdf5 {
 
@@ -50,6 +50,33 @@ bool absolute_path_string(const std::string &str)
     return false;
 }
 
+std::string join_string(const std::list<std::string> &to_join,
+                        const std::string &separator)
+{
+  std::ostringstream ss;
+  for (const auto &string_item : to_join)
+  {
+    ss << string_item << separator;
+  }
+  std::string result = ss.str();
+  if (!result.empty())
+    result.pop_back();  // remove trailing separator
+  return result;
+}
+
+std::list<std::string> split_string(const std::string &to_split,
+                                    char delim)
+{
+  std::stringstream ss(to_split);
+  std::string item;
+  std::list<std::string> elems;
+  while (std::getline(ss, item, delim)) {
+    if (!item.empty())
+      elems.push_back(std::move(item));
+  }
+  return elems;
+}
+
 std::list<std::string> str_to_list(const std::string &str)
 {
   std::list<std::string> result;
@@ -66,8 +93,7 @@ std::list<std::string> str_to_list(const std::string &str)
   if(str.back()=='/') string_end--;
 
   std::string buffer(string_start,string_end);
-  boost::split(result,buffer,
-               boost::is_any_of("/"),boost::token_compress_on);
+  result = split_string(buffer, '/');
   return result;
 }
 
@@ -86,7 +112,7 @@ std::string Path::to_string() const
   if (!absolute() && link_names_.empty())
     return ".";
   return (absolute() ? "/" : "")
-      + boost::algorithm::join(link_names_, "/");
+      + join_string(link_names_, "/");
 }
 
 Path::Path():

--- a/test/datatype/string_test.cpp
+++ b/test/datatype/string_test.cpp
@@ -24,7 +24,6 @@
 //
 
 #include <gtest/gtest.h>
-#include <boost/mpl/list.hpp>
 #include <h5cpp/datatype/factory.hpp>
 #include <h5cpp/datatype/string.hpp>
 #include <h5cpp/attribute/attribute.hpp>

--- a/test/node/dataset_test.cpp
+++ b/test/node/dataset_test.cpp
@@ -23,7 +23,6 @@
 // Created on: Sep 12, 2017
 //
 
-#include <boost/test/floating_point_comparison.hpp>
 #include <h5cpp/datatype/datatype.hpp>
 #include <h5cpp/property/dataset_creation.hpp>
 #include <h5cpp/property/dataset_access.hpp>

--- a/test/property/chunk_cache_parameters_test.cpp
+++ b/test/property/chunk_cache_parameters_test.cpp
@@ -26,7 +26,6 @@
 //
 
 #include <gtest/gtest.h>
-#include <boost/test/floating_point_comparison.hpp>
 #include <h5cpp/property/dataset_access.hpp>
 #include <h5cpp/property/property_class.hpp>
 

--- a/test/property/dataset_creation_test.cpp
+++ b/test/property/dataset_creation_test.cpp
@@ -26,7 +26,6 @@
 //
 
 #include <gtest/gtest.h>
-#include <boost/test/floating_point_comparison.hpp>
 #include <h5cpp/property/dataset_creation.hpp>
 #include <h5cpp/datatype/factory.hpp>
 

--- a/test/property/object_copy_test.cpp
+++ b/test/property/object_copy_test.cpp
@@ -26,7 +26,6 @@
 //
 
 #include <gtest/gtest.h>
-#include <boost/test/output_test_stream.hpp>
 #include <h5cpp/property/object_copy.hpp>
 
 using namespace hdf5;


### PR DESCRIPTION
These changes reduce the boost dependence to only the `filesystem` module and use the bincrafters `boost_filesystem` conan package only.

This should help to solve the current problem with the h5cpp package not working on Windows as well as significantly decrease the size of the library. It also makes it much harder to inadvertently add dependence on other parts of boost.

Closes #233 

It requires adding the bincrafters conan repository as a remote, which may need adding to some documentation?
```
conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
```