### PR TITLE
Fix Boost::system library not found problems

### DIFF
--- a/cmake/BoostLibraryConfig.cmake
+++ b/cmake/BoostLibraryConfig.cmake
@@ -3,12 +3,8 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
-find_package(Boost 1.41 COMPONENTS filesystem REQUIRED)
+find_package(Boost 1.41 COMPONENTS filesystem system REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
   add_definitions(-DBOOST_ALL_DYN_LINK)
 endif ()
-
-# Prevents requiring boost system,
-# may not be required when boost version >=1.67.0 is used
-add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -1,6 +1,7 @@
 [requires]
 cmake_findboost_modular/1.66.0@bincrafters/stable
 boost_filesystem/1.66.0@bincrafters/stable
+boost_system/1.66.0@bincrafters/stable
 hdf5/1.10.2-dm2@ess-dmsc/stable
 gtest/3121b20-dm3@ess-dmsc/stable
 
@@ -10,6 +11,7 @@ virtualbuildenv
 
 [options]
 boost_filesystem:shared=True
+boost_system:shared=True
 hdf5:shared=True
 hdf5:cxx=False
 gtest:shared=True

--- a/src/h5cpp/CMakeLists.txt
+++ b/src/h5cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(h5cpp SHARED
 add_doxygen_source_deps(${h5cpp_headers})
 
 target_compile_definitions(h5cpp PRIVATE DLL_BUILD)
-set(H5CPP_LINKS Boost::filesystem ${MPI_CXX_LIBRARIES})
+set(H5CPP_LINKS Boost::filesystem Boost::system ${MPI_CXX_LIBRARIES})
 
 #
 # remove the absolute path from the library name


### PR DESCRIPTION
Fixes #326 

Changes link Boost::system and add as explicit dependency.