### PR TITLE
Bring back Windows build on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,12 +246,6 @@ def get_win10_pipeline()
 
                 dir("_build") {
                     try {
-                        bat 'C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe install --build=outdated -s compiler="Visual Studio" -s compiler.version=14 ..\\conanfile_ess.txt'
-                    } catch (e) {
-                        failure_function(e, 'Windows10 / getting dependencies failed')
-                    }
-
-                    try {
                         bat 'cmake -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 14 2015 Win64" ..'
                     } catch (e) {
                         failure_function(e, 'Windows10 / CMake failed')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,6 +253,7 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
+                        bat "activate_run.bat"
                         bat "bin\\Release\\unit_tests.exe"
                     } catch (e) {
                         failure_function(e, 'Windows10 / build+test failed')
@@ -282,7 +283,7 @@ node('docker') {
     builders['macOS-release'] = get_macos_pipeline('Release')
     builders['macOS-debug'] = get_macos_pipeline('Debug')
     builders['Windows10'] = get_win10_pipeline()
-    
+
 
     parallel builders
     // Delete workspace when build is done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,8 +253,7 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
-                        abs_dir = pwd()
-                        bat """set PATH=%PATH%;${abs_dir}
+                        bat """call activate_run.bat
     	                       .\\bin\\Release\\unit_tests.exe
     	                    """
                     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,9 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
-                        bat "activate_run.bat && bin\\Release\\unit_tests.exe"
+                        bat """call activate_run.bat
+    	                       .\\bin\\Release\\unit_tests.exe
+    	                    """
                     } catch (e) {
                         failure_function(e, 'Windows10 / build+test failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,7 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
-                        bat "bin\\unit_tests.exe"
+                        bat "bin\\Release\\unit_tests.exe"
                     } catch (e) {
 		                junit 'test/unit_tests_run.xml'
                         failure_function(e, 'Windows10 / build+test failed')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,7 +253,8 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
-                        bat """call activate_run.bat
+                        abs_dir = pwd()
+                        bat """set PATH=%PATH%;${abs_dir}
     	                       .\\bin\\Release\\unit_tests.exe
     	                    """
                     } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,7 +255,6 @@ def get_win10_pipeline()
                         bat "cmake --build . --config Release --target unit_tests"
                         bat "bin\\Release\\unit_tests.exe"
                     } catch (e) {
-		                junit 'test/unit_tests_run.xml'
                         failure_function(e, 'Windows10 / build+test failed')
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def failure_function(exception_obj, failureMessage) {
         recipientProviders: toEmails,
         subject: '${DEFAULT_SUBJECT}'
     slackSend color: 'danger',
-        message: "@afonso.mukai ${project}-${env.BRANCH_NAME}: " + failureMessage
+        message: "${project}-${env.BRANCH_NAME}: " + failureMessage
 
     throw exception_obj
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,8 +253,7 @@ def get_win10_pipeline()
 
                     try {
                         bat "cmake --build . --config Release --target unit_tests"
-                        bat "activate_run.bat"
-                        bat "bin\\Release\\unit_tests.exe"
+                        bat "activate_run.bat && bin\\Release\\unit_tests.exe"
                     } catch (e) {
                         failure_function(e, 'Windows10 / build+test failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,8 +246,7 @@ def get_win10_pipeline()
 
                 dir("_build") {
                     try {
-                        bat 'C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe remote add desy-packages https://api.bintray.com/conan/eugenwintersberger/desy-packages'
-                        bat 'C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe install --build=outdated -s compiler="Visual Studio" -s compiler.version=14 ..\\conanfile_default.txt'
+                        bat 'C:\\Users\\dmgroup\\AppData\\Local\\Programs\\Python\\Python36\\Scripts\\conan.exe install --build=outdated -s compiler="Visual Studio" -s compiler.version=14 ..\\conanfile_ess.txt'
                     } catch (e) {
                         failure_function(e, 'Windows10 / getting dependencies failed')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,7 +289,7 @@ node('docker') {
     }
     builders['macOS-release'] = get_macos_pipeline('Release')
     builders['macOS-debug'] = get_macos_pipeline('Debug')
-//    builders['Windows10'] = get_win10_pipeline()
+    builders['Windows10'] = get_win10_pipeline()
     
 
     parallel builders

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -7,6 +7,7 @@ gtest/3121b20-dm3@ess-dmsc/stable
 [generators]
 cmake
 virtualbuildenv
+virtualrunenv
 
 [options]
 boost_filesystem:shared=True

--- a/conanfile_ess_mpi.txt
+++ b/conanfile_ess_mpi.txt
@@ -7,6 +7,7 @@ gtest/3121b20-dm3@ess-dmsc/stable
 [generators]
 cmake
 virtualbuildenv
+virtualrunenv
 
 [options]
 boost_filesystem:shared=True

--- a/src/h5cpp/core/path.cpp
+++ b/src/h5cpp/core/path.cpp
@@ -240,9 +240,8 @@ Path Path::relative_to(const Path &base) const
 
 void Path::append(const Path& p)
 {
-  std::copy(p.link_names_.begin(),
-            p.link_names_.end(),
-            std::back_inserter(link_names_));
+  for (const auto& pp : p.link_names_)
+    link_names_.emplace_back(pp);
 }
 
 Path& Path::operator+=(const Path &other)


### PR DESCRIPTION
Closes #288 

All Conan packages for dependencies now work on Windows. These changes reinstate the Windows build in the Jenkinsfile and uses Conan's virtualrunenv generator to ensure the shared libraries can be found.