### PR TITLE
issue 333

### DIFF
--- a/src/h5cpp/core/path.cpp
+++ b/src/h5cpp/core/path.cpp
@@ -27,6 +27,7 @@
 
 #include <h5cpp/core/path.hpp>
 #include <sstream>
+#include <stdexcept>
 
 namespace hdf5 {
 

--- a/src/h5cpp/core/path.cpp
+++ b/src/h5cpp/core/path.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <stdexcept>
 
+
 namespace hdf5 {
 
 //


### PR DESCRIPTION
fixes `runtime_error` is not a member of `std` on debian jessie and ubuntu 17.10