### PR TITLE
Issue_336

### DIFF
--- a/test/datatype/integer_test.cpp
+++ b/test/datatype/integer_test.cpp
@@ -69,7 +69,7 @@ Types<
 
 // The list of signed types we want to test.
 typedef
-Types<char, signed char, short, int, long, long long>
+Types<signed char, short, int, long, long long>
     test_signed_types;
 
 TYPED_TEST_CASE(Integer, test_types);

--- a/test/datatype/integer_test.cpp
+++ b/test/datatype/integer_test.cpp
@@ -69,8 +69,7 @@ Types<
 
 // The list of signed types we want to test.
 typedef
-Types<signed char, short, int, long, long long>
-    test_signed_types;
+Types<signed char, short, int, long, long long> test_signed_types;
 
 TYPED_TEST_CASE(Integer, test_types);
 TYPED_TEST_CASE(SignedInteger, test_signed_types);


### PR DESCRIPTION
It relaxes the tests for `char` because the c++ standard does not define if `char` is `signed` or `unsigned`. 