### PR TITLE
Set bash -e as build node shell command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,38 +5,38 @@ images = [
     'centos7-release': [
         'name': 'essdmscdm/centos7-build-node:3.0.0',
         'cmake': 'CC=/usr/lib64/mpich-3.2/bin/mpicc CXX=/usr/lib64/mpich-3.2/bin/mpicxx cmake3',
-        'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash',
+        'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e',
         'cmake_flags': '-DCOV=1 -DWITH_MPI=1 -DCONAN_FILE=conanfile_ess_mpi.txt -DCMAKE_BUILD_TYPE=Release'
     ],
     'debian9-release': [
         'name': 'essdmscdm/debian9-build-node:2.0.0',
         'cmake': 'cmake',
-        'sh': 'sh',
+        'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'
     ],
     'ubuntu1804-release': [
         'name': 'essdmscdm/ubuntu18.04-build-node:1.1.0',
         'cmake': 'cmake',
-        'sh': 'sh',
+        'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'
     ],
 
     'centos7-debug': [
             'name': 'essdmscdm/centos7-build-node:3.0.0',
             'cmake': 'CC=/usr/lib64/mpich-3.2/bin/mpicc CXX=/usr/lib64/mpich-3.2/bin/mpicxx cmake3',
-            'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash',
+            'sh': '/usr/bin/scl enable rh-python35 devtoolset-6 -- /bin/bash -e',
             'cmake_flags': '-DWITH_MPI=1 -DCONAN_FILE=conanfile_ess_mpi.txt -DCMAKE_BUILD_TYPE=Debug'
     ],
     'debian9-debug': [
             'name': 'essdmscdm/debian9-build-node:2.0.0',
             'cmake': 'cmake',
-            'sh': 'sh',
+            'sh': 'bash -e',
             'cmake_flags': '-DCMAKE_BUILD_TYPE=Debug'
     ],
     'ubuntu1804-debug': [
             'name': 'essdmscdm/ubuntu18.04-build-node:1.1.0',
             'cmake': 'cmake',
-            'sh': 'sh',
+            'sh': 'bash -e',
             'cmake_flags': '-DCMAKE_BUILD_TYPE=Debug'
     ]
 ]


### PR DESCRIPTION
This makes scripts exit with an error after the first failing command
and does not require using && to continue lines in scripts.