### PR TITLE
Extra type traits for using const

### DIFF
--- a/src/h5cpp/datatype/type_trait.hpp
+++ b/src/h5cpp/datatype/type_trait.hpp
@@ -66,10 +66,119 @@ class TypeTrait {
 template<>
 class TypeTrait<char> {
  public:
-
   using TypeClass = Integer;
   static TypeClass create(const char & = char()) {
     return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_CHAR)));
+  }
+};
+
+template<>
+class TypeTrait<std::int8_t const> {
+public:
+  using Type = std::int8_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_INT8)));
+  }
+};
+
+template<>
+class TypeTrait<std::uint8_t const> {
+public:
+  using Type = std::uint8_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_UINT8)));
+  }
+};
+
+template<>
+class TypeTrait<std::int16_t const> {
+public:
+  using Type = std::int16_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_INT16)));
+  }
+};
+
+template<>
+class TypeTrait<std::uint16_t const> {
+public:
+  using Type = std::uint16_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_UINT16)));
+  }
+};
+
+template<>
+class TypeTrait<std::int32_t const> {
+public:
+  using Type = std::int32_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_INT32)));
+  }
+};
+
+template<>
+class TypeTrait<std::uint32_t const> {
+public:
+  using Type = std::uint32_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_UINT32)));
+  }
+};
+
+template<>
+class TypeTrait<float const> {
+public:
+  using Type = float;
+  using TypeClass = Float;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_FLOAT)));
+  }
+};
+
+template<>
+class TypeTrait<double const> {
+public:
+  using Type = double;
+  using TypeClass = Float;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_DOUBLE)));
+  }
+};
+
+template<>
+class TypeTrait<char const> {
+public:
+  using Type = char;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_CHAR)));
+  }
+};
+
+template<>
+class TypeTrait<std::int64_t const> {
+public:
+  using Type = std::int64_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_INT64)));
+  }
+};
+
+template<>
+class TypeTrait<std::uint64_t const> {
+public:
+  using Type = std::uint64_t;
+  using TypeClass = Integer;
+  static TypeClass create(const Type & = Type()) {
+    return TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_UINT64)));
   }
 };
 

--- a/test/node/CMakeLists.txt
+++ b/test/node/CMakeLists.txt
@@ -15,6 +15,7 @@ set(test_sources
     ${dir}/dataset_extent_test.cpp
     ${dir}/dataset_partial_io_test.cpp
     ${dir}/dataset_array_type_io.cpp
+    ${dir}/dataset_const_data.cpp
     ${dir}/dataset_vlen_array_io.cpp
     ${dir}/dataset_fixed_string_io.cpp
     ${dir}/dataset_variable_string_io.cpp

--- a/test/node/dataset_const_data.cpp
+++ b/test/node/dataset_const_data.cpp
@@ -1,0 +1,51 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5pp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Created on: Oct 23, 2017
+//
+#include <gtest/gtest.h>
+#include <h5cpp/hdf5.hpp>
+#include <array>
+#include <cstdint>
+
+using namespace hdf5;
+
+template<class Type>
+void constData() {
+  std::array<const Type,1> SomeData{0};
+  node::Dataset dset;
+  dset.write(SomeData);
+}
+
+void DoNotRun() {
+  constData<std::int8_t>();
+  constData<std::uint8_t>();
+  constData<std::int16_t>();
+  constData<std::uint16_t>();
+  constData<std::int32_t>();
+  constData<std::uint32_t>();
+  constData<std::int64_t>();
+  constData<std::uint64_t>();
+  constData<double>();
+  constData<float>();
+  constData<char>();
+}


### PR DESCRIPTION
This pull request is a friendly reminder that the use of const is still not supported by h5cpp. Although I have for now fixed the problem in my code by adding 100 lines of code of TypeTrait specialisations it would be nice if I did not have to do that.

Closes #277 