### PR TITLE
fixed ssize_t redefined [win32]

### DIFF
--- a/src/h5cpp/core/windows.hpp
+++ b/src/h5cpp/core/windows.hpp
@@ -36,9 +36,11 @@
 #endif
 
 #ifdef _MSC_VER
-#include <BaseTsd.h>
-
-using ssize_t = SSIZE_T;
-
+#if defined _M_IX86
+    using ssize_t = int;
+#elif defined _M_X64
+    #include <BaseTsd.h>
+    using ssize_t = SSIZE_T;
+#endif
 #endif
 


### PR DESCRIPTION
Fixed build (error C2371: 'ssize_t': redefinition;) for win32