### PR TITLE
renamed keywords for POSIX clashes

### DIFF
--- a/src/h5cpp/file/direct_driver.cpp
+++ b/src/h5cpp/file/direct_driver.cpp
@@ -86,7 +86,7 @@ void DirectDriver::operator()(const property::FileAccessList &fapl) const
 
 DriverID DirectDriver::id() const noexcept
 {
-  return DriverID::DIRECT;
+  return DriverID::eDIRECT;
 }
 
 } // namespace file

--- a/src/h5cpp/file/driver.hpp
+++ b/src/h5cpp/file/driver.hpp
@@ -45,10 +45,10 @@ namespace file {
 //!
 enum class DriverID : unsigned {
 
-  POSIX = 1,
-  DIRECT = 2,
-  MEMORY = 3,
-  MPI    = 4
+  ePOSIX = 1,
+  eDIRECT = 2,
+  eMEMORY = 3,
+  eMPI    = 4
 };
 
 //!

--- a/src/h5cpp/file/memory_driver.cpp
+++ b/src/h5cpp/file/memory_driver.cpp
@@ -69,7 +69,7 @@ void MemoryDriver::operator()(const property::FileAccessList &fapl) const
 
 DriverID MemoryDriver::id() const noexcept
 {
-  return DriverID::MEMORY;
+  return DriverID::eMEMORY;
 }
 
 }

--- a/src/h5cpp/file/mpi_driver.cpp
+++ b/src/h5cpp/file/mpi_driver.cpp
@@ -48,7 +48,7 @@ void MPIDriver::operator()(const property::FileAccessList &fapl) const
 
 DriverID MPIDriver::id() const noexcept
 {
-  return DriverID::MPI;
+  return DriverID::eMPI;
 }
 
 #endif

--- a/src/h5cpp/file/posix_driver.cpp
+++ b/src/h5cpp/file/posix_driver.cpp
@@ -42,7 +42,7 @@ void PosixDriver::operator()(const property::FileAccessList &fapl) const
 
 DriverID PosixDriver::id() const noexcept
 {
-  return DriverID::POSIX;
+  return DriverID::ePOSIX;
 }
 
 } // namespace file


### PR DESCRIPTION
In response to #392, and because I needed a project using Dlib and h5cpp, I have renamed the keywords. It is now compiling with Dlib.