### PR TITLE
Issue 401: update version to 0.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(h5cpp
     LANGUAGES CXX C
-    VERSION 0.3.0
+    VERSION 0.1.3
     )
 
 #=============================================================================

--- a/doc/source/users_guide/installing.rst
+++ b/doc/source/users_guide/installing.rst
@@ -140,7 +140,7 @@ to update your package list and
 
 .. code-block:: bash
 
-   $ apt-get install libh5cpp0.1.0 libh5cpp0.1.0-dbg libh5cpp0.1.0-doc libh5cpp0.1.0-dev
+   $ apt-get install libh5cpp0.1.3 libh5cpp0.1.3-dbg libh5cpp0.1.3-doc libh5cpp0.1.3-dev
 
-to install the library of v0.1.0. Dependencies will be resolved automatically so you can
+to install the library of v0.1.3. Dependencies will be resolved automatically so you can
 start with working right after the installation has finished.


### PR DESCRIPTION
It updates the h5cpp version to 0.1.3 in `CMakeLists.txt` (to fix documentation)  and in `install.rst` to have recent debian packages  shown.