### PR TITLE
Issue 412

### DIFF
--- a/src/h5cpp/node/dataset.hpp
+++ b/src/h5cpp/node/dataset.hpp
@@ -727,7 +727,7 @@ void Dataset::write(const T &data,const dataspace::Selection &selection,
 {
   auto memory_space = hdf5::dataspace::create(data);
   auto memory_type  = hdf5::datatype::create(data);
-  
+
   dataspace::Dataspace file_space = dataspace();
   file_space.selection(dataspace::SelectionOperation::SET,selection);
   try{
@@ -744,7 +744,7 @@ void Dataset::write(const T &data,const dataspace::Selection &selection,
       write(data,memory_type,selected_space,file_space,dtpl);
     else
       write(data,memory_type,memory_space,file_space,dtpl);
-      
+
   }
   catch(const std::bad_cast&){
     write(data,memory_type,memory_space,file_space,dtpl);

--- a/src/h5cpp/node/dataset.hpp
+++ b/src/h5cpp/node/dataset.hpp
@@ -730,24 +730,31 @@ void Dataset::write(const T &data,const dataspace::Selection &selection,
 
   dataspace::Dataspace file_space = dataspace();
   file_space.selection(dataspace::SelectionOperation::SET,selection);
-  try{
-
-    const dataspace::Hyperslab & hyper = dynamic_cast<const dataspace::Hyperslab &>(selection);
-
-    auto dims = hyper.block();
-    auto count = hyper.count();
-    for(Dimensions::size_type i = 0; i != dims.size(); i++)
-      dims[i] *= count[i];
-    dataspace::Simple selected_space(dims);
-    if(selected_space.rank() > 1 &&
-       selected_space.size() == memory_space.size())
-      write(data,memory_type,selected_space,file_space,dtpl);
-    else
-      write(data,memory_type,memory_space,file_space,dtpl);
-
-  }
-  catch(const std::bad_cast&){
+  if (memory_space.type() == dataspace::Type::SCALAR) {
     write(data,memory_type,memory_space,file_space,dtpl);
+  }
+  else{
+    try{
+
+      const dataspace::Hyperslab & hyper = dynamic_cast<const dataspace::Hyperslab &>(selection);
+      const dataspace::Simple & mem_space = dataspace::Simple(memory_space);
+
+      auto dims = hyper.block();
+      auto count = hyper.count();
+      for(Dimensions::size_type i = 0; i != dims.size(); i++)
+	dims[i] *= count[i];
+      dataspace::Simple selected_space(dims);
+      if(selected_space.rank() > 1 &&
+	 mem_space.rank() == 1 &&
+	 selected_space.size() == memory_space.size())
+	write(data,memory_type,selected_space,file_space,dtpl);
+      else
+	write(data,memory_type,memory_space,file_space,dtpl);
+
+    }
+    catch(const std::bad_cast&){
+      write(data,memory_type,memory_space,file_space,dtpl);
+    }
   }
 }
 

--- a/src/h5cpp/node/dataset.hpp
+++ b/src/h5cpp/node/dataset.hpp
@@ -637,6 +637,16 @@ void Dataset::write(const T &data,const property::DatasetTransferList &dtpl) con
   auto file_space  = dataspace();
   file_space.selection.all();
 
+  if (file_space.size() == memory_space.size() &&
+      memory_space.type() == dataspace::Type::SIMPLE &&
+      file_space.type() == dataspace::Type::SIMPLE){
+    const dataspace::Simple & mem_space = dataspace::Simple(memory_space);
+    const dataspace::Simple & fl_space = dataspace::Simple(file_space);
+    if(fl_space.rank() > 1 && mem_space.rank() == 1){
+      write(data,memory_type,file_space,file_space,dtpl);
+      return;
+    }
+  }
   write(data,memory_type,memory_space,file_space,dtpl);
 }
 
@@ -730,7 +740,7 @@ void Dataset::write(const T &data,const dataspace::Selection &selection,
 
   dataspace::Dataspace file_space = dataspace();
   file_space.selection(dataspace::SelectionOperation::SET,selection);
-  if (memory_space.type() == dataspace::Type::SCALAR) {
+  if (memory_space.type() != dataspace::Type::SIMPLE) {
     write(data,memory_type,memory_space,file_space,dtpl);
   }
   else{

--- a/src/h5cpp/node/link_view.cpp
+++ b/src/h5cpp/node/link_view.cpp
@@ -124,6 +124,7 @@ bool LinkView::exists(const std::string &name, const property::LinkAccessList &l
       <<group().link().path()<<"]!";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
+  return false;
 }
 
 LinkView::const_iterator LinkView::begin() const

--- a/src/h5cpp/node/node_view.cpp
+++ b/src/h5cpp/node/node_view.cpp
@@ -111,6 +111,7 @@ bool NodeView::exists(const std::string &name, const property::LinkAccessList &l
       <<group().link().path()<<"]!";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
+  return false;
 }
 
 NodeView::const_iterator NodeView::begin() const

--- a/test/node/CMakeLists.txt
+++ b/test/node/CMakeLists.txt
@@ -36,6 +36,7 @@ set(test_sources
     ${dir}/dataset_h5py_bool_test.cpp
     ${dir}/dataset_pniio_bool_test.cpp
     ${dir}/dataset_read_speed_test.cpp
+    ${dir}/dataset_write_speed_test.cpp
     PARENT_SCOPE)
 
 set(test_headers

--- a/test/node/dataset_write_speed_test.cpp
+++ b/test/node/dataset_write_speed_test.cpp
@@ -82,7 +82,7 @@ protected:
     }
 
   virtual void TearDown() {
-    //    fs::remove("dataset_write_speed.h5");
+    fs::remove("dataset_write_speed.h5");
   }
 };
 

--- a/test/node/dataset_write_speed_test.cpp
+++ b/test/node/dataset_write_speed_test.cpp
@@ -203,7 +203,7 @@ TEST_F(DatasetWriteSpeedTest, write)
     std::vector<unsigned short int> buffer(first, last);
     EXPECT_EQ(buffer, read_value);
   }
-  
+
 }
 
 #endif

--- a/test/node/dataset_write_speed_test.cpp
+++ b/test/node/dataset_write_speed_test.cpp
@@ -1,0 +1,136 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5pp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Author: Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Nov 12, 2018
+//
+
+#include <gtest/gtest.h>
+#include <h5cpp/file/functions.hpp>
+#include <h5cpp/node/group.hpp>
+#include <h5cpp/dataspace/hyperslab.hpp>
+#include <boost/filesystem.hpp>
+#ifndef _MSC_VER
+#include <sys/time.h>
+#endif
+
+using namespace hdf5;
+namespace fs = boost::filesystem;
+
+struct DatasetWriteSpeedTest : public testing::Test
+{
+  long long unsigned int xdim = 867;
+  long long unsigned int ydim = 700;
+  long long unsigned int nframe = 33;
+  hdf5::file::File f;
+  hdf5::node::Group root;
+  hdf5::dataspace::Simple space;
+  hdf5::dataspace::Simple memspace;
+  property::DatasetCreationList dcpl;
+  property::LinkCreationList lcpl;
+  property::DatasetAccessList dapl;
+  std::vector<unsigned short int> frame;
+  dataspace::Hyperslab framespace;
+  property::DatasetTransferList dtpl;
+
+  DatasetWriteSpeedTest()
+  {
+#if H5_VERSION_GE(1, 10, 0)
+    property::FileCreationList fcpl;
+    property::FileAccessList fapl;
+    fapl.library_version_bounds(property::LibVersion::LATEST,
+                                property::LibVersion::LATEST);
+    f = file::create("dataset_write_speed.h5", file::AccessFlags::TRUNCATE, fcpl, fapl);
+#else
+    f = file::create("dataset_write_speed.h5", file::AccessFlags::TRUNCATE);
+#endif
+    root = f.root();
+    space =  {{0, xdim, ydim}, {dataspace::Simple::UNLIMITED,
+				dataspace::Simple::UNLIMITED,
+				dataspace::Simple::UNLIMITED}};
+    memspace = {{xdim, ydim}, {dataspace::Simple::UNLIMITED,
+			       dataspace::Simple::UNLIMITED}};
+
+    dcpl.layout(property::DatasetLayout::CHUNKED);
+    dcpl.chunk({1, xdim, ydim});
+    frame = std::vector<unsigned short int>(xdim*ydim);
+    framespace = dataspace::Hyperslab({{0, 0, 0}, {1, xdim, ydim}});
+
+  }
+
+protected:
+  virtual void SetUp()
+  {
+    }
+
+  virtual void TearDown() {
+    //    fs::remove("dataset_write_speed.h5");
+  }
+};
+
+#ifndef _MSC_VER
+TEST_F(DatasetWriteSpeedTest, write)
+{
+  struct timeval stime1;
+  struct timeval etime1;
+  struct timeval stime0;
+  struct timeval etime0;
+
+  auto dtype = datatype::create<unsigned short int>();
+  node::Dataset data0 = node::Dataset(root, "data0", dtype, space, lcpl, dcpl, dapl);
+  gettimeofday(&stime0, NULL);
+  for(long long unsigned int i = 0; i != nframe; i++){
+    data0.extent(0, 1);
+    framespace.offset({i, 0, 0});
+    dataspace::Dataspace file_space = data0.dataspace();
+    file_space.selection(dataspace::SelectionOperation::SET, framespace);
+    data0.write(frame, dtype, memspace, file_space, dtpl);
+  }
+  gettimeofday(&etime0, NULL);
+
+  node::Dataset data1 = node::Dataset(root,
+				      "data1",
+				      datatype::create<unsigned short int>(),
+				      space,lcpl,dcpl,dapl);
+
+
+  gettimeofday(&stime1, NULL);
+
+  for(long long unsigned int i = 0; i != nframe; i++){
+    data1.extent(0, 1);
+    framespace.offset({i, 0, 0});
+
+    data1.write(frame, framespace);
+  }
+  gettimeofday(&etime1, NULL);
+
+  double time0 = (double)(etime0.tv_sec - stime0.tv_sec)
+    + (double)(etime0.tv_usec - stime0.tv_usec)*0.000001;
+  double time1 = (double)(etime1.tv_sec - stime1.tv_sec)
+    + (double)(etime1.tv_usec - stime1.tv_usec)*0.000001;
+
+  std::cerr << time0 <<  std::endl;
+  std::cerr << time1 <<  std::endl;
+  EXPECT_GT(14 * time1, time0);
+  EXPECT_GT(14 * time0, time1);
+}
+
+#endif

--- a/test/node/dataset_write_speed_test.cpp
+++ b/test/node/dataset_write_speed_test.cpp
@@ -46,7 +46,6 @@ struct DatasetWriteSpeedTest : public testing::Test
   hdf5::dataspace::Simple fullspace;
   hdf5::dataspace::Simple memspace;
   property::DatasetCreationList dcpl;
-  property::DatasetCreationList dcpl2;
   property::LinkCreationList lcpl;
   property::DatasetAccessList dapl;
   std::vector<unsigned short int> frame;
@@ -79,8 +78,6 @@ struct DatasetWriteSpeedTest : public testing::Test
     dcpl.chunk({1, xdim, ydim});
     frame = std::vector<unsigned short int>(xdim * ydim);
     framespace = dataspace::Hyperslab({{0, 0, 0}, {1, xdim, ydim}});
-    dcpl2.layout(property::DatasetLayout::CHUNKED);
-    dcpl2.chunk({nframe, xdim, ydim});
     allframes = std::vector<unsigned short int>(nframe * xdim * ydim);
 
   }

--- a/test/node/dataset_write_speed_test.cpp
+++ b/test/node/dataset_write_speed_test.cpp
@@ -50,7 +50,7 @@ struct DatasetWriteSpeedTest : public testing::Test
   property::DatasetAccessList dapl;
   std::vector<unsigned short int> frame;
   std::vector<unsigned short int> allframes;
-  
+
   dataspace::Hyperslab framespace;
   property::DatasetTransferList dtpl;
 
@@ -198,8 +198,8 @@ TEST_F(DatasetWriteSpeedTest, write)
     data3.extent(0, 1);
     framespace.offset({i, 0, 0});
     data3.read(read_value, framespace);
-    auto first = allframes.begin() + i*xdim * ydim;
-    auto last = allframes.begin() + (i + 1)*xdim * ydim;
+    auto first = allframes.begin() + i * xdim * ydim;
+    auto last = allframes.begin() + (i + 1) * xdim * ydim;
     std::vector<unsigned short int> buffer(first, last);
     EXPECT_EQ(buffer, read_value);
   }


### PR DESCRIPTION
In this PR I provide a workaround for the problem defined in #412, i.e. during writing fields when `memory_space` does not match to `file_space` in the `write` method with an selection parameter `H5Dwrite` do writing ~24 slower because of iterating over all points the the input data. 

It happens often when a user wants to write image data from a linear `std::vector<T>` variable.   The fix and tests are similar to ones with #379 with an additional check if input data is a linear buffer (with rank=1).