### PR TITLE
Fixed compiler warnings

### DIFF
--- a/src/h5cpp/attribute/attribute_manager.cpp
+++ b/src/h5cpp/attribute/attribute_manager.cpp
@@ -129,6 +129,7 @@ bool AttributeManager::exists(const std::string &name) const
       <<node_.link().path()<<"]!";
     error::Singleton::instance().throw_with_stack(ss.str());
   }
+  return {};
 }
 
 Attribute AttributeManager::create(const std::string &name,

--- a/src/h5cpp/core/object_handle.cpp
+++ b/src/h5cpp/core/object_handle.cpp
@@ -74,7 +74,7 @@ ObjectHandle::ObjectHandle(ObjectHandle &&o) noexcept
 }
 
 //-------------------------------------------------------------------------
-ObjectHandle::~ObjectHandle()
+ObjectHandle::~ObjectHandle() noexcept
 {
   try
   {
@@ -284,6 +284,7 @@ ObjectHandle::Type ObjectHandle::get_type() const
       ss << "ObjectHandle: unknown object type=" << type;
       error::Singleton::instance().throw_with_stack(ss.str());
   };
+  return {};
 }
 
 //----------------------------------------------------------------------------
@@ -291,7 +292,7 @@ void ObjectHandle::increment_reference_count() const
 {
   if (H5Iinc_ref(handle_) < 0)
   {
-    //Failing to succesfully inrement the reference counter for an internal
+    //Failing to succesfully increment the reference counter for an internal
     //object ID is a serious issue and justifies to throw an exception here.
     error::Singleton::instance().throw_with_stack("ObjectHandle: could not increment reference counter");
   }

--- a/src/h5cpp/dataspace/dataspace.hpp
+++ b/src/h5cpp/dataspace/dataspace.hpp
@@ -86,13 +86,6 @@ class DLL_EXPORT Dataspace {
   Dataspace &operator=(const Dataspace &space);
 
   //!
-  //! \brief move assignment
-  //!
-  //! Use default compiler implementation here.
-  //!
-  Dataspace &operator=(Dataspace &&type) = default;
-
-  //!
   //! \brief number of elements in the dataspace
   //!
   //! \throws std::runtime_error in case of a failure

--- a/src/h5cpp/dataspace/selection_manager.cpp
+++ b/src/h5cpp/dataspace/selection_manager.cpp
@@ -28,6 +28,7 @@
 #include <h5cpp/dataspace/dataspace.hpp>
 #include <h5cpp/dataspace/selection.hpp>
 #include <h5cpp/error/error.hpp>
+#include <cassert>
 
 namespace hdf5 {
 namespace dataspace {
@@ -49,11 +50,14 @@ size_t SelectionManager::size() const {
 
 SelectionType SelectionManager::type() const {
   switch (H5Sget_select_type(static_cast<hid_t>(space_))) {
+    case H5S_SEL_ERROR:return SelectionType::NONE;
     case H5S_SEL_NONE:return SelectionType::NONE;
     case H5S_SEL_POINTS:return SelectionType::POINTS;
     case H5S_SEL_HYPERSLABS:return SelectionType::HYPERSLAB;
     case H5S_SEL_ALL:return SelectionType::ALL;
+    case H5S_SEL_N:assert(false); // Added H5S_SEL_N to silence compiler
   }
+  return {};
 }
 
 void SelectionManager::all() const {

--- a/src/h5cpp/property/creation_order.hpp
+++ b/src/h5cpp/property/creation_order.hpp
@@ -114,8 +114,11 @@ class DLL_EXPORT CreationOrder {
  private:
   unsigned tracked_:1;
   unsigned indexed_:1;
+#ifdef WIN32
   unsigned reserved_:sizeof(unsigned) - 2;
-
+#else
+  __attribute__((unused)) unsigned reserved_:sizeof(unsigned) - 2;
+#endif
 };
 
 }  // namespace property

--- a/src/h5cpp/property/dataset_creation.cpp
+++ b/src/h5cpp/property/dataset_creation.cpp
@@ -100,6 +100,7 @@ DatasetLayout DatasetCreationList::layout() const {
 #endif
     default:error::Singleton::instance().throw_with_stack("Failure retrieving the dataset layout!");
   }
+  return {};
 }
 
 void DatasetCreationList::chunk(const Dimensions &chunk_dims) const {

--- a/src/h5cpp/property/property_class.cpp
+++ b/src/h5cpp/property/property_class.cpp
@@ -66,7 +66,7 @@ bool operator==(const Class &lhs, const Class &rhs) {
     return false;
   else
     error::Singleton::instance().throw_with_stack("Could check equality of property list classes");
-
+  return {};
 }
 
 bool operator!=(const Class &lhs, const Class &rhs) {
@@ -77,6 +77,7 @@ bool operator!=(const Class &lhs, const Class &rhs) {
     return true;
   else
     error::Singleton::instance().throw_with_stack("Could check inequality of property list classes");
+  return {};
 }
 
 const Class kAttributeCreate = Class(ObjectHandle(H5P_ATTRIBUTE_CREATE,


### PR DESCRIPTION
The latest version of clang has improved compiler warnings. This causes problems when treating warnings as errors. I have thus fixed these warnings (plus a typo).