### PR TITLE
fix for a warning with  INSTANTIATE_TEST_CASE_P

### DIFF
--- a/test/core/ObjectHandleDefault.cpp
+++ b/test/core/ObjectHandleDefault.cpp
@@ -142,7 +142,7 @@ INSTANTIATE_TEST_CASE_P(ObjHandleTest, ObjHandleFixture,
                                           hdf5::ObjectHandle::Type::PROPERTY_LIST,
                                           hdf5::ObjectHandle::Type::ERROR_MESSAGE,
                                           hdf5::ObjectHandle::Type::ERROR_CLASS,
-                                          hdf5::ObjectHandle::Type::ERROR_STACK));
+                                          hdf5::ObjectHandle::Type::ERROR_STACK),);
 
 //  //hdf5::ObjectHandle::Type::PROPERTY_LIST_CLASS));
 


### PR DESCRIPTION
By adding comma one can workaround
```
/home/jkotan/sources/h5cpp/test/core/ObjectHandleDefault.cpp:145:81: warning: ISO C++11 requires at least one argument for the "..." in a variadic macro
                                           hdf5::ObjectHandle::Type::ERROR_STACK));
                                                                                 ^
```
i.e. fix issue #422