### PR TITLE
Add option to disable building unit tests and improve Jenkinsfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ list(APPEND CMAKE_MODULE_PATH ${EXTRA_MODULES_DIR})
 # Conan
 #=============================================================================
 # SET(CONAN_DISABLE_CHECK_COMPILER TRUE)
-SET(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
-SET(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")
+set(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
+set(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")
 set(CONAN_FILE "conanfile_ess.txt" CACHE STRING "The conanfile to use for the build")
 if(${CONAN} MATCHES "AUTO")
   include(${EXTRA_MODULES_DIR}/ConanSetup.cmake)
@@ -29,10 +29,10 @@ elseif(${CONAN} MATCHES "MANUAL")
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     conan_basic_setup(NO_OUTPUT_DIRS SKIP_RPATH)
   else()
-    MESSAGE(FATAL_ERROR "CONAN set to MANUAL but no file named conanbuildinfo.cmake found in build directory")
+    message(FATAL_ERROR "CONAN set to MANUAL but no file named conanbuildinfo.cmake found in build directory")
   endif()
 elseif(NOT ${CONAN} MATCHES "DISABLE")
-  MESSAGE(FATAL_ERROR "Unrecognised option for CONAN (${CONAN}), use AUTO, MANUAL or DISABLE")
+  message(FATAL_ERROR "Unrecognised option for CONAN (${CONAN}), use AUTO, MANUAL or DISABLE")
 endif()
 
 #=============================================================================
@@ -71,11 +71,14 @@ install(DIRECTORY examples
 #=============================================================================
 # unit tests if GTest if present
 #=============================================================================
-include(${EXTRA_MODULES_DIR}/FindGTestFix.cmake)
-if(GTest_FOUND)
-  add_subdirectory(test)
-else()
-  message(WARNING "GTest not found. No tests will be built.")
+set(DISABLE_TESTS False CACHE BOOL "Disable building unit tests")
+if(NOT DISABLE_TESTS)
+  include(${EXTRA_MODULES_DIR}/FindGTestFix.cmake)
+  if(GTest_FOUND)
+    add_subdirectory(test)
+  else()
+    message(WARNING "GTest not found. No tests will be built.")
+  endif()
 endif()
 
 #=============================================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,13 +10,13 @@ images = [
     ],
 */    
     'debian9-release': [
-        'name': 'screamingudder/debian9-build-node:3.5.0',
+        'name': 'screamingudder/debian9-build-node:3.5.1',
         'cmake': 'cmake',
         'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'
     ],
     'ubuntu1804-release': [
-        'name': 'screamingudder/ubuntu18.04-build-node:3.0.0',
+        'name': 'screamingudder/ubuntu18.04-build-node:3.0.2',
         'cmake': 'cmake',
         'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,13 +10,13 @@ images = [
     ],
 */    
     'debian9-release': [
-        'name': 'essdmscdm/debian9-build-node:3.0.0',
+        'name': 'screamingudder/debian9-build-node:3.5.0',
         'cmake': 'cmake',
         'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'
     ],
     'ubuntu1804-release': [
-        'name': 'essdmscdm/ubuntu18.04-build-node:2.0.0',
+        'name': 'screamingudder/ubuntu18.04-build-node:3.0.0',
         'cmake': 'cmake',
         'sh': 'bash -e',
         'cmake_flags': '-DCMAKE_BUILD_TYPE=Release'

--- a/conanfile_desi.txt
+++ b/conanfile_desi.txt
@@ -2,7 +2,7 @@
 cmake_findboost_modular/1.66.0@bincrafters/stable
 boost_filesystem/1.66.0@bincrafters/stable
 hdf5/1.10.1@eugenwintersberger/testing
-gtest/1.8.0@conan/stable
+gtest/1.10.0
 zlib/1.2.8@conan/stable
 bzip2/1.0.6@conan/stable
 

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -2,7 +2,7 @@
 cmake_findboost_modular/1.69.0@bincrafters/stable
 boost_filesystem/1.69.0@bincrafters/stable
 hdf5/1.10.5-dm2@ess-dmsc/stable
-gtest/3121b20-dm3@ess-dmsc/stable
+gtest/1.10.0
 
 [generators]
 cmake

--- a/conanfile_ess_mpi.txt
+++ b/conanfile_ess_mpi.txt
@@ -2,7 +2,7 @@
 cmake_findboost_modular/1.69.0@bincrafters/stable
 boost_filesystem/1.69.0@bincrafters/stable
 hdf5/1.10.5-dm2@ess-dmsc/stable
-gtest/3121b20-dm3@ess-dmsc/stable
+gtest/1.10.0
 
 [generators]
 cmake

--- a/test/gtest_print.hpp
+++ b/test/gtest_print.hpp
@@ -31,13 +31,6 @@ namespace testing
 {
 namespace internal
 {
-enum GTestColor {
-  COLOR_DEFAULT,
-  COLOR_RED,
-  COLOR_GREEN,
-  COLOR_YELLOW
-};
-
 extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
 }
 }


### PR DESCRIPTION
Closes #431

Added CMake option `DISABLE_TESTS` to disable building unit tests, which we don't need for example when building a conan package of the library.

Updated the Jenkinsfile to use our jenkins pipeline library, which simplifies the file quite a bit.
I've also fixed and enabled the CentOS and Mac builds which had been commented out.

I've also updated the gtest package used, which allows me to build successfully with gcc 9.2.

I'm not sure if #399 can be considered closed, but these changes should at least be a step in the right direction.
