### PR TITLE
Issue 439: fixes the GTestColor problem for GTest < 1.10

### DIFF
--- a/test/gtest_print.hpp
+++ b/test/gtest_print.hpp
@@ -31,12 +31,14 @@ namespace testing
 {
 namespace internal
 {
+#ifndef GTestColor
 enum GTestColor {
   kDefault,
   kRed,
   kGreen,
   kYellow
 };
+#endif
 extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
 }
 }

--- a/test/gtest_print.hpp
+++ b/test/gtest_print.hpp
@@ -31,18 +31,16 @@ namespace testing
 {
 namespace internal
 {
-#ifndef GTestColor
-enum GTestColor {
+enum LocalGTestColor {
   kDefault,
   kRed,
   kGreen,
   kYellow
 };
-#endif
-extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+extern void ColoredPrintf(LocalGTestColor color, const char* fmt, ...);
 }
 }
-#define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::kGreen, "[          ] "); testing::internal::ColoredPrintf(testing::internal::kYellow, __VA_ARGS__); } while(0)
+#define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::LocalGTestColor::kGreen, "[          ] "); testing::internal::ColoredPrintf(testing::internal::LocalGTestColor::kYellow, __VA_ARGS__); } while(0)
 
 // C++ stream interface
 class TestCout : public std::stringstream

--- a/test/gtest_print.hpp
+++ b/test/gtest_print.hpp
@@ -31,16 +31,16 @@ namespace testing
 {
 namespace internal
 {
-enum LocalGTestColor {
-  COLOR_DEFAULT,
-  COLOR_RED,
-  COLOR_GREEN,
-  COLOR_YELLOW
+enum GTestColor {
+  kDefault,
+  kRed,
+  kGreen,
+  kYellow
 };
-extern void ColoredPrintf(LocalGTestColor color, const char* fmt, ...);
+extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
 }
 }
-#define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::COLOR_GREEN, "[          ] "); testing::internal::ColoredPrintf(testing::internal::COLOR_YELLOW, __VA_ARGS__); } while(0)
+#define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::kGreen, "[          ] "); testing::internal::ColoredPrintf(testing::internal::kYellow, __VA_ARGS__); } while(0)
 
 // C++ stream interface
 class TestCout : public std::stringstream

--- a/test/gtest_print.hpp
+++ b/test/gtest_print.hpp
@@ -31,7 +31,13 @@ namespace testing
 {
 namespace internal
 {
-extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+enum LocalGTestColor {
+  COLOR_DEFAULT,
+  COLOR_RED,
+  COLOR_GREEN,
+  COLOR_YELLOW
+};
+extern void ColoredPrintf(LocalGTestColor color, const char* fmt, ...);
 }
 }
 #define PRINTF(...)  do { testing::internal::ColoredPrintf(testing::internal::COLOR_GREEN, "[          ] "); testing::internal::ColoredPrintf(testing::internal::COLOR_YELLOW, __VA_ARGS__); } while(0)


### PR DESCRIPTION
it resolves #439 by defining LocalGTestColor enum