### PR TITLE
Issue 460: fix for warning C4273 on windows

### DIFF
--- a/src/h5cpp/dataspace/simple.cpp
+++ b/src/h5cpp/dataspace/simple.cpp
@@ -61,7 +61,8 @@ void Simple::dimensions(const Dimensions &current, const Dimensions &maximum) {
   if (maximum.empty())
     maximum_ptr = current.data();
 
-  if (H5Sset_extent_simple(static_cast<hid_t>(*this), current.size(), current_ptr,
+  if (H5Sset_extent_simple(static_cast<hid_t>(*this),
+			   static_cast<int>(current.size()), current_ptr,
                            maximum_ptr) < 0) {
     error::Singleton::instance().throw_with_stack("Failure setting the dimensions for a simple dataspace!");
   }

--- a/src/h5cpp/datatype/array.cpp
+++ b/src/h5cpp/datatype/array.cpp
@@ -45,7 +45,7 @@ Array::Array(const Datatype &type) :
 }
 
 Array Array::create(const Datatype &base_type, const Dimensions &dims) {
-  hid_t ret = H5Tarray_create(static_cast<hid_t>(base_type), dims.size(), dims.data());
+  hid_t ret = H5Tarray_create(static_cast<hid_t>(base_type), static_cast<int>(dims.size()), dims.data());
   if (ret < 0) {
     std::stringstream ss;
     ss << "Could not create Array of base=" << base_type.get_class();

--- a/src/h5cpp/datatype/compound.cpp
+++ b/src/h5cpp/datatype/compound.cpp
@@ -55,7 +55,7 @@ Compound Compound::create(size_t size) {
 }
 
 Datatype Compound::operator[](size_t index) const {
-  hid_t id = H5Tget_member_type(static_cast<hid_t>(*this), index);
+  hid_t id = H5Tget_member_type(static_cast<hid_t>(*this), static_cast<int>(index));
   if (id < 0) {
     std::stringstream ss;
     ss << "Failure to obtain data type for field [" << index << "] in compound data type!";
@@ -80,7 +80,7 @@ size_t Compound::field_index(const std::string &name) const {
 
 // implementation same as for Enum
 std::string Compound::field_name(size_t index) const {
-  char *buffer = H5Tget_member_name(static_cast<hid_t>(*this), index);
+  char *buffer = H5Tget_member_name(static_cast<hid_t>(*this), static_cast<int>(index));
   if (buffer == NULL) {
     std::stringstream ss;
     ss << "Failure to obtain name of field [" << index << "] in compound data type!";
@@ -102,7 +102,7 @@ size_t Compound::field_offset(const std::string &name) const {
 }
 
 size_t Compound::field_offset(size_t index) const {
-  size_t offset = H5Tget_member_offset(static_cast<hid_t>(*this), index);
+  size_t offset = H5Tget_member_offset(static_cast<hid_t>(*this), static_cast<int>(index));
   if (offset == 0) {
     // if offset == 0, there could be a field at 0, or there could be nothing
     try {
@@ -123,7 +123,7 @@ Class Compound::field_class(const std::string &name) const {
 }
 
 Class Compound::field_class(size_t index) const {
-  H5T_class_t value = H5Tget_member_class(static_cast<hid_t>(*this), index);
+  H5T_class_t value = H5Tget_member_class(static_cast<hid_t>(*this), static_cast<int>(index));
   if (value < 0) {
     std::stringstream ss;
     ss << "Failure to obtain type class for field [" << index << "] in compound type!";

--- a/src/h5cpp/datatype/ebool.cpp
+++ b/src/h5cpp/datatype/ebool.cpp
@@ -35,7 +35,7 @@ namespace datatype
 {
 
 bool is_bool(const Enum & etype){
-  int s = etype.number_of_values();
+  size_t s = etype.number_of_values();
   if(s != 2){
     return false;
   }

--- a/src/h5cpp/file/functions.hpp
+++ b/src/h5cpp/file/functions.hpp
@@ -101,11 +101,11 @@ DLL_EXPORT bool is_hdf5_file(const fs::path &path);
 //! \sa ImageFlags
 //!
 template<typename T>
-DLL_EXPORT File from_buffer(T &data,
-			    ImageFlags flags = ImageFlags::READONLY);
+File from_buffer(T &data,
+		 ImageFlags flags = ImageFlags::READONLY);
 template<typename T>
-DLL_EXPORT File from_buffer(T &data,
-			    ImageFlagsBase flags);
+File from_buffer(T &data,
+		 ImageFlagsBase flags);
 
 
 

--- a/src/h5cpp/node/dataset.cpp
+++ b/src/h5cpp/node/dataset.cpp
@@ -229,7 +229,7 @@ void resize_by(const Dataset &dataset,size_t dimension_index,ssize_t delta)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #endif
-  if((delta<0) && (current_dims[dimension_index]<abs(delta)))
+  if((delta<0) && (current_dims[dimension_index] < static_cast<hsize_t>(abs(delta))))
   {
     std::stringstream ss;
     ss<<"Extent of dataset ["<<dataset.link().path()<<"] cannot be changed "

--- a/src/h5cpp/property/dataset_creation.cpp
+++ b/src/h5cpp/property/dataset_creation.cpp
@@ -104,7 +104,9 @@ DatasetLayout DatasetCreationList::layout() const {
 }
 
 void DatasetCreationList::chunk(const Dimensions &chunk_dims) const {
-  if (H5Pset_chunk(static_cast<hid_t>(*this), chunk_dims.size(), chunk_dims.data()) < 0) {
+  if (H5Pset_chunk(static_cast<hid_t>(*this),
+		   static_cast<int>(chunk_dims.size()),
+		   chunk_dims.data()) < 0) {
     error::Singleton::instance().throw_with_stack("Failure setting chunk dimensions!");
   }
 }

--- a/test/attribute/attribute_scalar_io_test.cpp
+++ b/test/attribute/attribute_scalar_io_test.cpp
@@ -44,8 +44,8 @@ TEST_F(AttributeScalarIO, test_uint8)
 TEST_F(AttributeScalarIO, test_float32)
 {
   attribute::Attribute a = root_.attributes.create<float>("data");
-  float write_value = 3.213e-2;
-  float read_value = 0.0;
+  float write_value = 3.213e-2f;
+  float read_value = 0.0f;
   a.write(write_value);
   a.read(read_value);
   EXPECT_NEAR(write_value,read_value,0.001);

--- a/test/core/object_id_test.cpp
+++ b/test/core/object_id_test.cpp
@@ -110,7 +110,8 @@ struct FileGuard
                                              H5P_DEFAULT,
                                              H5P_DEFAULT));
       Dimensions dims{3,3};
-      ObjectHandle space(H5Screate_simple(dims.size(),dims.data(),nullptr));
+      ObjectHandle space(H5Screate_simple(static_cast<int>(dims.size()),
+					  dims.data(),nullptr));
       dataset_handle = ObjectHandle(H5Dcreate(static_cast<hid_t>(group1_handle),
                                               "dset1",
                                               H5T_NATIVE_DOUBLE,

--- a/test/datatype/float_test.cpp
+++ b/test/datatype/float_test.cpp
@@ -46,7 +46,11 @@ typedef
 Types<float, double, long double>
     test_types;
 
+#ifdef TYPED_TEST_SUITE
+TYPED_TEST_SUITE(Float, test_types);
+#else
 TYPED_TEST_CASE(Float, test_types);
+#endif
 
 TYPED_TEST(Float, Exceptions) {
   datatype::Datatype dtype;

--- a/test/datatype/integer_test.cpp
+++ b/test/datatype/integer_test.cpp
@@ -71,9 +71,15 @@ Types<
 typedef
 Types<signed char, short, int, long, long long> test_signed_types;
 
+#ifdef TYPED_TEST_SUITE
+TYPED_TEST_SUITE(Integer, test_types);
+TYPED_TEST_SUITE(SignedInteger, test_signed_types);
+TYPED_TEST_SUITE(UnsignedInteger, test_unsigned_types);
+#else
 TYPED_TEST_CASE(Integer, test_types);
 TYPED_TEST_CASE(SignedInteger, test_signed_types);
 TYPED_TEST_CASE(UnsignedInteger, test_unsigned_types);
+#endif
 
 TYPED_TEST(Integer, Exceptions) {
   datatype::Datatype dtype;

--- a/test/datatype/string_test.cpp
+++ b/test/datatype/string_test.cpp
@@ -66,7 +66,11 @@ Types<std::string>
 //std::u32string>
     test_types;
 
+#ifdef TYPED_TEST_SUITE
+TYPED_TEST_SUITE(String, test_types);
+#else
 TYPED_TEST_CASE(String, test_types);
+#endif
 
 TEST(String, Constructor) {
   datatype::Datatype dtype;

--- a/test/error/error_test.cpp
+++ b/test/error/error_test.cpp
@@ -41,7 +41,7 @@ class Error : public testing::Test
     // redirect stderr into buf
     fflush(stderr);
     std::memset(buf, 0, bufsize);
-    setbuf(stderr, buf);
+    setvbuf(stderr, buf);
   }
 
   std::string extract_string()
@@ -55,7 +55,7 @@ class Error : public testing::Test
   virtual void TearDown()
   {
     // return stderr to normal function
-    setbuf(stderr, NULL);
+    setvbuf(stderr, NULL);
   }
 
   std::stringstream ss;

--- a/test/error/error_test.cpp
+++ b/test/error/error_test.cpp
@@ -41,7 +41,7 @@ class Error : public testing::Test
     // redirect stderr into buf
     fflush(stderr);
     std::memset(buf, 0, bufsize);
-    setvbuf(stderr, buf);
+    setvbuf(stderr, buf, _IOFBF, bufsize);
   }
 
   std::string extract_string()
@@ -55,7 +55,7 @@ class Error : public testing::Test
   virtual void TearDown()
   {
     // return stderr to normal function
-    setvbuf(stderr, NULL);
+    setvbuf(stderr, NULL, _IONBF, bufsize);
   }
 
   std::stringstream ss;

--- a/test/node/dataset_direct_chunk_test.cpp
+++ b/test/node/dataset_direct_chunk_test.cpp
@@ -81,10 +81,10 @@ struct DatasetDirectChunkTest : public testing::Test
 
     sframe = std::vector<unsigned short int>(sxdim);
     for(size_t i = 0; i != sxdim; i++)
-      sframe[i] = i / 2;
+      sframe[i] = static_cast<int>(i / 2);
     tframe = std::vector<unsigned short int>(sxdim);
     for(size_t i = 0; i != sxdim; i++)
-      tframe[i] = i / 4;
+      tframe[i] = static_cast<int>(i / 4);
 
     sspace =  {{0, sxdim}, {dataspace::Simple::UNLIMITED,
 			   dataspace::Simple::UNLIMITED}};

--- a/test/utilities/array_adapter_test.cpp
+++ b/test/utilities/array_adapter_test.cpp
@@ -48,7 +48,7 @@ class ArrayAdapterTest : public testing::Test
     // redirect stderr into buf
     integer_data = new int[bufsize];
     for (size_t index = 0; index < bufsize; index++)
-      integer_data[index] = index;
+      integer_data[index] = static_cast<int>(index);
   }
 
   virtual void TearDown()


### PR DESCRIPTION
The PR resolves #460 by fixing the warning C4273 on windows by removing DLL_EXPORT from the `from_buffer` function.

It also fixes a couple of other warnings like, e.g.  warning C4267: '=': conversion from 'size_t' to 'unsigned short

except C4251 and C4275 which require to add more extern declaration so  it is better to place them in a separate PR. 