### PR TITLE
Issue 466: disable C4251 windows warnings

### DIFF
--- a/src/h5cpp/core/object_id.hpp
+++ b/src/h5cpp/core/object_id.hpp
@@ -151,7 +151,14 @@ class DLL_EXPORT ObjectId
  private:
     unsigned long file_num_ {0};
     haddr_t       obj_addr_ {0};
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     fs::path   file_name_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 

--- a/src/h5cpp/dataspace/points.hpp
+++ b/src/h5cpp/dataspace/points.hpp
@@ -114,7 +114,14 @@ class DLL_EXPORT Points : public Selection
 
   private:
     size_t rank_{ 0 };
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     std::vector<hsize_t> coordinates_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 } // namespace dataspace

--- a/src/h5cpp/error/descriptor.hpp
+++ b/src/h5cpp/error/descriptor.hpp
@@ -59,6 +59,10 @@ struct DLL_EXPORT Descriptor
 
   hid_t       maj_num;	// major error ID
   hid_t       min_num;	// minor error number
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
   std::string major;         // major error text
   std::string minor;         // minor error text
 
@@ -66,6 +70,9 @@ struct DLL_EXPORT Descriptor
   std::string function;      // function in which error occurred
   std::string file;          // file in which error occurred
   std::string description;   // supplied description
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 //!

--- a/src/h5cpp/filter/external_filter.hpp
+++ b/src/h5cpp/filter/external_filter.hpp
@@ -80,7 +80,14 @@ class DLL_EXPORT ExternalFilter : public Filter
     const std::vector<unsigned int> cd_values() const noexcept;
 
   private:
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     const std::vector<unsigned int> cd_values_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 

--- a/src/h5cpp/node/link.hpp
+++ b/src/h5cpp/node/link.hpp
@@ -89,7 +89,14 @@ class DLL_EXPORT LinkTarget
     hdf5::Path object_path() const;
 
   private:
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     fs::path file_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     hdf5::Path              object_path_;
 };
 

--- a/src/h5cpp/node/recursive_link_iterator.hpp
+++ b/src/h5cpp/node/recursive_link_iterator.hpp
@@ -133,10 +133,17 @@ class DLL_EXPORT RecursiveLinkIterator
     //!
     LinkIterator    current_iterator_;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     //!
     //! Pointer to the parent interator if there is one
     //!
     IteratorPointer parent_iterator_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 
 

--- a/src/h5cpp/node/recursive_node_iterator.hpp
+++ b/src/h5cpp/node/recursive_node_iterator.hpp
@@ -181,10 +181,17 @@ class DLL_EXPORT RecursiveNodeIterator
     //!
     NodeIterator    current_iterator_;
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
     //!
     //! Pointer to the parent interator if there is one
     //!
     IteratorPointer parent_iterator_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 
 

--- a/src/h5cpp/property/virtual_data_map.hpp
+++ b/src/h5cpp/property/virtual_data_map.hpp
@@ -87,12 +87,23 @@ class DLL_EXPORT VirtualDataMap {
 
  private:
   dataspace::View target_view_;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
   fs::path source_file_;
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
   hdf5::Path source_dataset_;
   dataspace::View source_view_;
 
 };
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
 //!
 //! \brief utility container for virtual data maps
 //!
@@ -101,6 +112,9 @@ class DLL_EXPORT VirtualDataMap {
 //! The interface is exactly the same as for std::vector.
 //!
 class DLL_EXPORT VirtualDataMaps : public std::vector<VirtualDataMap> {
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
  public:
   //
   // pull in std::vector constructors


### PR DESCRIPTION
It resolves #466 by hiding C4251 windows warnings
With the PR the windows built looks more cleaner, i.e.
https://jenkins.esss.dk/dm/blue/organizations/jenkins/ess-dmsc%2Fh5cpp/detail/issue_466/1/pipeline/28