### PR TITLE
Issue 468: include missing headers in hdf5.hpp

### DIFF
--- a/src/h5cpp/hdf5.hpp
+++ b/src/h5cpp/hdf5.hpp
@@ -45,6 +45,7 @@
 
 #include <h5cpp/datatype/compound.hpp>
 #include <h5cpp/datatype/datatype.hpp>
+#include <h5cpp/datatype/ebool.hpp>
 #include <h5cpp/datatype/factory.hpp>
 #include <h5cpp/datatype/float.hpp>
 #include <h5cpp/datatype/integer.hpp>
@@ -52,8 +53,11 @@
 #include <h5cpp/datatype/types.hpp>
 #include <h5cpp/datatype/string.hpp>
 #include <h5cpp/datatype/array.hpp>
+#include <h5cpp/datatype/enum.hpp>
 
 #include <h5cpp/dataspace/dataspace.hpp>
+#include <h5cpp/dataspace/hyperslab.hpp>
+#include <h5cpp/dataspace/points.hpp>
 #include <h5cpp/dataspace/scalar.hpp>
 #include <h5cpp/dataspace/selection_manager.hpp>
 #include <h5cpp/dataspace/selection.hpp>
@@ -118,3 +122,5 @@
 #if H5_VERSION_GE(1,10,0)
 #include <h5cpp/property/virtual_data_map.hpp>
 #endif
+
+#include <h5cpp/utilities/array_adapter.hpp>


### PR DESCRIPTION
It resolves #468 by including missing headers in hdf5.hpp