### PR TITLE
Issue 388: add ExternalFilters class and Dataset::filters() method 

### DIFF
--- a/src/h5cpp/filter/external_filter.cpp
+++ b/src/h5cpp/filter/external_filter.cpp
@@ -49,6 +49,13 @@ ExternalFilter::ExternalFilter(FilterID id,
 {
 }
 
+ExternalFilter::ExternalFilter():
+    Filter(0),
+    cd_values_(0, 0),
+    name_("")
+{
+}
+
 ExternalFilter::~ExternalFilter()
 {}
 

--- a/src/h5cpp/filter/external_filter.cpp
+++ b/src/h5cpp/filter/external_filter.cpp
@@ -40,9 +40,12 @@ bool is_filter_available(FilterID id){
 }
 
 
-ExternalFilter::ExternalFilter(FilterID id, const std::vector<unsigned int> cd_values):
+ExternalFilter::ExternalFilter(FilterID id,
+			       const std::vector<unsigned int> cd_values,
+			       const std::string &name):
     Filter(id),
-    cd_values_(cd_values)
+    cd_values_(cd_values),
+    name_(name)
 {
 }
 
@@ -65,6 +68,68 @@ const std::vector<unsigned int> ExternalFilter::cd_values() const noexcept
   return cd_values_;
 }
 
+const std::string ExternalFilter::name() const noexcept
+{
+  return name_;
+}
+
+const std::vector<Availability> ExternalFilters::fill(const property::DatasetCreationList &dcpl,
+						      size_t max_cd_number,
+						      size_t max_name_size)
+{
+  std::vector<Availability> flags;
+  int nfilters = H5Pget_nfilters(static_cast<hid_t>(dcpl));
+  if(nfilters < 0)
+  {
+      std::stringstream ss;
+      ss<<"Failure to read a number of filters from " << dcpl.get_class();
+      error::Singleton::instance().throw_with_stack(ss.str());
+  }
+
+  unsigned int flag;
+  size_t cd_number = max_cd_number;
+  std::vector<char> fname(max_name_size);
+
+  for(int nf=0; nf != nfilters; nf++)
+  {
+    std::vector<unsigned int> cd_values(max_cd_number);
+    int filter_id = H5Pget_filter(static_cast<hid_t>(dcpl),
+			      nf,
+			      &flag,
+			      &cd_number,
+			      cd_values.data(),
+			      fname.size(),
+			      fname.data(),
+			      NULL);
+    if(nfilters < 0)
+    {
+      std::stringstream ss;
+      ss << "Failure to read a parameters of filter ("
+	 << nf << ") from " << dcpl.get_class();
+      error::Singleton::instance().throw_with_stack(ss.str());
+    }
+    if(cd_number > max_cd_number)
+    {
+      std::stringstream ss;
+      ss<<"Too many filter parameters in " << dcpl.get_class();
+      error::Singleton::instance().throw_with_stack(ss.str());
+    }
+    cd_values.resize(cd_number);
+    if(static_cast<int>(static_cast<Availability>(flag)) != flag)
+    {
+      std::stringstream ss;
+      ss<<"Wrong filter flag value in " << dcpl.get_class();
+      error::Singleton::instance().throw_with_stack(ss.str());
+    }
+
+    Availability fflag = static_cast<Availability>(flag);
+    fname[max_name_size - 1] = '\0';
+    std::string name(fname.data());
+    push_back(ExternalFilter(filter_id, cd_values, name));
+    flags.push_back(fflag);
+  }
+  return flags;
+}
 
 } // namespace filter
 } // namespace hdf5

--- a/src/h5cpp/filter/external_filter.hpp
+++ b/src/h5cpp/filter/external_filter.hpp
@@ -53,7 +53,9 @@ class DLL_EXPORT ExternalFilter : public Filter
     //! \param id the ID of the filter
     //! \param cd_values is a vector with compression options.
     //!
-    ExternalFilter(FilterID id, const std::vector<unsigned int> cd_values);
+    ExternalFilter(FilterID id,
+                   const std::vector<unsigned int> cd_values,
+                   const std::string &name=std::string());
     ExternalFilter() = delete;
     ~ExternalFilter();
 
@@ -73,11 +75,19 @@ class DLL_EXPORT ExternalFilter : public Filter
     //!
     //! \brief compression options
     //!
-    //! Provdies compression options of the external filter
+    //! Provides compression options of the external filter
     //!
     //! \return compression options
     //!
     const std::vector<unsigned int> cd_values() const noexcept;
+    //!
+    //! \brief compression options
+    //!
+    //! Provides the external filter name
+    //!
+    //! \return filter name
+    //!
+    const std::string name() const noexcept;
 
   private:
 #ifdef _MSC_VER
@@ -85,9 +95,48 @@ class DLL_EXPORT ExternalFilter : public Filter
 #pragma warning(disable: 4251)
 #endif
     const std::vector<unsigned int> cd_values_;
+    const std::string name_;
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+};
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+//!
+//! \brief utility container for external filters
+//!
+//! This is a one to one derived type from std::vector in order to provide
+//! a convenient container for external filters.
+//! The interface is exactly the same as for std::vector.
+//!
+class DLL_EXPORT ExternalFilters : public std::vector<ExternalFilter> {
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+ public:
+
+  //!
+  //! \brief apply filter
+  //!
+  //! Fills a filter list with filters from a particular dataset creation property list.
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //! \param dcpl reference to the dataset creation property list
+  //! \param max_cd_number maximal numer of cd_values
+  //! \param max_name_size maximal fileter name size
+  //! \return filter flags
+  //!
+  //!
+  const std::vector<Availability> fill(const property::DatasetCreationList &dcpl,
+				       size_t max_cd_number=16,
+				       size_t max_name_size=257);
+  //
+  // pull in std::vector constructors
+  //
+  using std::vector<ExternalFilter>::vector;
 };
 
 

--- a/src/h5cpp/filter/external_filter.hpp
+++ b/src/h5cpp/filter/external_filter.hpp
@@ -94,8 +94,8 @@ class DLL_EXPORT ExternalFilter : public Filter
 #pragma warning(push)
 #pragma warning(disable: 4251)
 #endif
-    const std::vector<unsigned int> cd_values_;
-    const std::string name_;
+    std::vector<unsigned int> cd_values_;
+    std::string name_;
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/src/h5cpp/filter/external_filter.hpp
+++ b/src/h5cpp/filter/external_filter.hpp
@@ -56,6 +56,7 @@ class DLL_EXPORT ExternalFilter : public Filter
     ExternalFilter(FilterID id,
                    const std::vector<unsigned int> cd_values,
                    const std::string &name=std::string());
+    ExternalFilter();
     ~ExternalFilter();
 
     //!

--- a/src/h5cpp/filter/external_filter.hpp
+++ b/src/h5cpp/filter/external_filter.hpp
@@ -56,7 +56,6 @@ class DLL_EXPORT ExternalFilter : public Filter
     ExternalFilter(FilterID id,
                    const std::vector<unsigned int> cd_values,
                    const std::string &name=std::string());
-    ExternalFilter() = delete;
     ~ExternalFilter();
 
     //!

--- a/src/h5cpp/node/dataset.cpp
+++ b/src/h5cpp/node/dataset.cpp
@@ -19,7 +19,10 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Jan Kotanski <jan.kotanski@desy.de>
+//
 // Created on: Sep 12, 2017
 //
 
@@ -27,6 +30,7 @@
 #include <stdexcept>
 #include <h5cpp/node/dataset.hpp>
 #include <h5cpp/node/functions.hpp>
+#include <h5cpp/filter/external_filter.hpp>
 #include <h5cpp/error/error.hpp>
 
 namespace hdf5 {
@@ -200,6 +204,13 @@ long long unsigned int Dataset::chunk_storage_size(
 void Dataset::write(const char *data,const property::DatasetTransferList &dtpl) const
 {
   write(std::string(data),dtpl);
+}
+
+filter::ExternalFilters Dataset::filters() const
+{
+  filter::ExternalFilters efilters = filter::ExternalFilters();
+  efilters.fill(creation_list());
+  return efilters;
 }
 
 void resize_by(const Dataset &dataset,size_t dimension_index,ssize_t delta)

--- a/src/h5cpp/node/dataset.hpp
+++ b/src/h5cpp/node/dataset.hpp
@@ -39,6 +39,7 @@
 #include <h5cpp/property/link_creation.hpp>
 #include <h5cpp/property/dataset_creation.hpp>
 #include <h5cpp/property/dataset_access.hpp>
+#include <h5cpp/filter/external_filter.hpp>
 #include <h5cpp/error/error.hpp>
 
 namespace hdf5 {
@@ -387,6 +388,16 @@ class DLL_EXPORT Dataset : public Node
               const dataspace::Selection &file_selection,
               const property::DatasetTransferList &dtpl = property::DatasetTransferList()) const;
 
+    //!
+    //! \brief get the dataset external filters for the instance
+    //!
+    //! Returns an instance of the dataset external filters for the
+    //! dataset.
+    //!
+    //! \throws std::runtime_error in case of a failure
+    //! \return instance of ExternalFilters
+    //!
+    filter::ExternalFilters filters() const;
 
   private:
     //!

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -51,8 +51,8 @@ TEST(ExternalFilterTest, bitshufflelz4_construction)
 
     filter::ExternalFilters filters;
     auto flags = filters.fill(dcpl);
-    EXPECT_EQ(filters.size(), 1);
-    EXPECT_EQ(flags.size(), 1);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(flags.size(), 1lu);
     EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
     EXPECT_EQ(filters[0].cd_values(), cdvalues);
     EXPECT_EQ(filters[0].id(), FILTER_BITSHUFFLE);
@@ -71,8 +71,8 @@ TEST(ExternalFilterTest, deflate_application)
   filter::ExternalFilters filters;
   auto flags = filters.fill(dcpl);
   // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
-  EXPECT_EQ(filters.size(), 1);
-  EXPECT_EQ(flags.size(), 1);
+  EXPECT_EQ(filters.size(), 1lu);
+  EXPECT_EQ(flags.size(), 1lu);
   EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
   EXPECT_EQ(filters[0].cd_values(), cdvalues);
   EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -48,14 +48,33 @@ TEST(ExternalFilterTest, bitshufflelz4_construction)
   EXPECT_EQ(bfilter.id(), static_cast<int>(FILTER_BITSHUFFLE));
   if(filter::is_filter_available(FILTER_BITSHUFFLE)){
     EXPECT_NO_THROW(bfilter(dcpl));
+
+    filter::ExternalFilters filters;
+    auto flags = filters.fill(dcpl);
+    EXPECT_EQ(filters.size(), 1);
+    EXPECT_EQ(flags.size(), 1);
+    EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
+    EXPECT_EQ(filters[0].cd_values(), cdvalues);
+    EXPECT_EQ(filters[0].id(), FILTER_BITSHUFFLE);
+    EXPECT_EQ(filters[0].name(),
+	      "bitshuffle; see https://github.com/kiyo-masui/bitshuffle");
   }
 }
 
 TEST(ExternalFilterTest, deflate_application)
 {
   property::DatasetCreationList dcpl;
+  std::vector<unsigned int> cdvalues({8u});
   filter::ExternalFilter filter(H5Z_FILTER_DEFLATE, {8u});
 
   filter(dcpl);
-  EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+  filter::ExternalFilters filters;
+  auto flags = filters.fill(dcpl);
+  // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+  EXPECT_EQ(filters.size(), 1);
+  EXPECT_EQ(flags.size(), 1);
+  EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
+  EXPECT_EQ(filters[0].cd_values(), cdvalues);
+  EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
+  EXPECT_EQ(filters[0].name(), "deflate");
 }

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -78,3 +78,29 @@ TEST(ExternalFilterTest, deflate_application)
   EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
   EXPECT_EQ(filters[0].name(), "deflate");
 }
+
+TEST(ExternalFilterTest, deflate_shuffle_application)
+{
+  property::DatasetCreationList dcpl;
+  std::vector<unsigned int> cdvalues({8u});
+  std::vector<unsigned int> cdvalues2({});
+  filter::ExternalFilter filter(H5Z_FILTER_DEFLATE, {8u});
+  filter::Shuffle shuffle;
+
+  filter(dcpl);
+  shuffle(dcpl);
+
+  filter::ExternalFilters filters;
+  auto flags = filters.fill(dcpl);
+  // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+  EXPECT_EQ(filters.size(), 2lu);
+  EXPECT_EQ(flags.size(), 2lu);
+  EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
+  EXPECT_EQ(flags[1], filter::Availability::OPTIONAL);
+  EXPECT_EQ(filters[0].cd_values(), cdvalues);
+  EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
+  EXPECT_EQ(filters[0].name(), "deflate");
+  EXPECT_EQ(filters[1].cd_values(), cdvalues2);
+  EXPECT_EQ(filters[1].id(), static_cast<int>(H5Z_FILTER_SHUFFLE));
+  EXPECT_EQ(filters[1].name(), "shuffle");
+}

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -55,7 +55,7 @@ TEST(ExternalFilterTest, bitshufflelz4_construction)
     EXPECT_EQ(flags.size(), 1lu);
     EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
     EXPECT_EQ(filters[0].cd_values(), cdvalues);
-    EXPECT_EQ(filters[0].id(), FILTER_BITSHUFFLE);
+    EXPECT_EQ(filters[0].id(), static_cast<int>(FILTER_BITSHUFFLE));
     EXPECT_EQ(filters[0].name(),
 	      "bitshuffle; see https://github.com/kiyo-masui/bitshuffle");
   }

--- a/test/node/dataset_direct_chunk_test.cpp
+++ b/test/node/dataset_direct_chunk_test.cpp
@@ -254,7 +254,7 @@ TEST_F(DatasetDirectChunkTest, write_chunk_deflate)
 
   auto filters = data4.filters();
   std::vector<unsigned int> cdvalues({2u});
-  EXPECT_EQ(filters.size(), 1);
+  EXPECT_EQ(filters.size(), 1lu);
   EXPECT_EQ(filters[0].cd_values(), cdvalues);
   EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
   EXPECT_EQ(filters[0].name(), "deflate");

--- a/test/node/dataset_direct_chunk_test.cpp
+++ b/test/node/dataset_direct_chunk_test.cpp
@@ -204,7 +204,7 @@ TEST_F(DatasetDirectChunkTest, read_chunk_deflate)
 	filter_mask = data3.read_chunk(tread_value, {i, 0});
 	EXPECT_EQ(tcpvalue, tread_value);
       }
-      
+
     EXPECT_EQ(filter_mask, H5P_DEFAULT);
   }
 }
@@ -233,7 +233,7 @@ TEST_F(DatasetDirectChunkTest, write_chunk_deflate)
   std::vector<unsigned short int> tcpframe =  {24184, 24675, 128, 1606, 25608, 32866,
 					       26176, 2054, 24932, 0, 20993, 7424};
 
-  
+
   for(long long unsigned int i = 0; i != nframe; i++){
     data4.extent(0, 1);
     if(i % 2)
@@ -251,5 +251,12 @@ TEST_F(DatasetDirectChunkTest, write_chunk_deflate)
     else
       EXPECT_EQ(tframe, read_value);
   }
-}
 
+  auto filters = data4.filters();
+  std::vector<unsigned int> cdvalues({2u});
+  EXPECT_EQ(filters.size(), 1);
+  EXPECT_EQ(filters[0].cd_values(), cdvalues);
+  EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
+  EXPECT_EQ(filters[0].name(), "deflate");
+
+}

--- a/test/node/dataset_h5py_string_compat_test.cpp
+++ b/test/node/dataset_h5py_string_compat_test.cpp
@@ -62,7 +62,7 @@ TEST_F(H5pyStringCompatTest, test_read_scalar_string_utf8)
   dataset.read(buffer, datatype, dataspace);
   // 'Hello UTF8! Pr\xf3ba \u6d4b'
   const std::string su = "Hello UTF8! Pr""\xc3""\xb3""ba ""\xe6""\xb5""\x8b";
-  EXPECT_EQ(buffer.size(), 1);
+  EXPECT_EQ(buffer.size(), 1lu);
   EXPECT_EQ(buffer[0], su);
 }
 
@@ -74,7 +74,7 @@ TEST_F(H5pyStringCompatTest, test_read_scalar_string_simple_utf8)
 
   // 'Hello UTF8! Pr\xf3ba \u6d4b'
   const std::string su = "Hello UTF8! Pr""\xc3""\xb3""ba ""\xe6""\xb5""\x8b";
-  EXPECT_EQ(buffer.size(), 1);
+  EXPECT_EQ(buffer.size(), 1lu);
   EXPECT_EQ(buffer[0], su);
 }
 


### PR DESCRIPTION
It resolves #388 by adding `ExternalFilters` class and `Dataset::filters()` method and `ExternalFilter::name()` method
```c++
+    //!
+    //! \brief get the dataset external filters for the instance
+    //!
+    //! Returns an instance of the dataset external filters for the
+    //! dataset.
+    //!
+    //! \throws std::runtime_error in case of a failure
+    //! \return instance of ExternalFilters
+    //!
+    filter::ExternalFilters filters() const;
```
```c++
+    ExternalFilter(FilterID id,
+                   const std::vector<unsigned int> cd_values,
+                   const std::string &name=std::string());
+    ExternalFilter();
+    //!
+    //! \brief compression options
+    //!
+    //! Provides the external filter name
+    //!
+    //! \return filter name
+    //!
+    const std::string name() const noexcept;
```
```c++
+//!
+//! \brief utility container for external filters
+//!
+//! This is a one to one derived type from std::vector in order to provide
+//! a convenient container for external filters.
+//! The interface is exactly the same as for std::vector.
+//!
+class DLL_EXPORT ExternalFilters : public std::vector<ExternalFilter> {
+  //!
+  //! \brief apply filter
+  //!
+  //! Fills a filter list with filters from a particular dataset creation property list.
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //! \param dcpl reference to the dataset creation property list
+  //! \param max_cd_number maximal numer of cd_values
+  //! \param max_name_size maximal fileter name size
+  //! \return filter flags
+  //!
+  //!
+  const std::vector<Availability> fill(const property::DatasetCreationList &dcpl,
+                                      size_t max_cd_number=16,
+                                      size_t max_name_size=257);
+  //
}
```

It helps to retrieve informations about dataset filters.