### PR TITLE
Issue 434: add access for missing datatype properties and float16_t type

### DIFF
--- a/src/h5cpp/datatype/float.cpp
+++ b/src/h5cpp/datatype/float.cpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 23, 2017
 //
 
@@ -44,9 +45,142 @@ Float::Float(const Datatype &datatype) :
   }
 }
 
+
+size_t Float::precision() const {
+  size_t p = H5Tget_precision(static_cast<hid_t>(*this));
+  if (p == 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype precision");
+  }
+  return p;
+}
+
+void Float::precision(size_t precision) const {
+  if (H5Tset_precision(static_cast<hid_t>(*this), precision) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype precision to " << precision;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+size_t Float::offset() const {
+  ssize_t p = H5Tget_offset(static_cast<hid_t>(*this));
+  if (p < 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype offset");
+  }
+  return p;
+}
+
+void Float::offset(size_t offset) const {
+  if (H5Tset_offset(static_cast<hid_t>(*this), offset) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype offset to " << offset;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+Order Float::order() const {
+  htri_t ret = H5Tget_order(static_cast<hid_t>(*this));
+  if (ret > 4) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype order");
+  }
+  return static_cast<Order>(ret);
+}
+
+void Float::order(Order order) const {
+  if (H5Tset_order(static_cast<hid_t>(*this), static_cast<H5T_order_t>(order)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype order to " << order;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+const std::vector<Pad> Float::pad() const {
+  H5T_pad_t lsb;
+  H5T_pad_t msb;
+  std::vector<Pad> pads(2);
+  htri_t ret = H5Tget_pad(static_cast<hid_t>(*this), &lsb, &msb);
+  if (ret < 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype order");
+  }
+  pads[0] = static_cast<Pad>(lsb);
+  pads[1] = static_cast<Pad>(msb);
+  return pads;
+}
+
+void Float::pad(Pad lsb, Pad msb) const {
+  if (H5Tset_pad(static_cast<hid_t>(*this),
+		 static_cast<H5T_pad_t>(lsb),
+		 static_cast<H5T_pad_t>(msb)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype pad to (" << lsb << ", " << msb << ")" ;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+const std::vector<size_t> Float::fields() const {
+  std::vector<size_t> fields(5);
+  if (H5Tget_fields(static_cast<hid_t>(*this), &fields[0], &fields[1], &fields[2], &fields[3], &fields[4]) < 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype fields");
+  }
+  return fields;
+}
+
+void Float::fields(size_t spos, size_t epos, size_t esize, size_t mpos, size_t msize) const {
+  if (H5Tset_fields(static_cast<hid_t>(*this), spos, epos, esize, mpos, msize) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype fields to ("
+       << spos << ", " <<  epos << ", " <<  esize << ", " <<  mpos << ", " <<  msize << ")" ;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+size_t Float::ebias() const {
+  ssize_t p = H5Tget_ebias(static_cast<hid_t>(*this));
+  if (p == 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype ebias");
+  }
+  return p;
+}
+
+void Float::ebias(size_t ebias) const {
+  if (H5Tset_ebias(static_cast<hid_t>(*this), ebias) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype ebias to " << ebias;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+Norm Float::norm() const {
+  H5T_norm_t ret = H5Tget_norm(static_cast<hid_t>(*this));
+  if (ret == H5T_NORM_ERROR) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype norm");
+  }
+  return static_cast<Norm>(ret);
+}
+
+void Float::norm(Norm norm) const {
+  if (H5Tset_norm(static_cast<hid_t>(*this), static_cast<H5T_norm_t>(norm)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype norm to " << norm;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+Pad Float::inpad() const {
+  H5T_pad_t ret = H5Tget_inpad(static_cast<hid_t>(*this));
+  if (ret == H5T_PAD_ERROR) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype inpad");
+  }
+  return static_cast<Pad>(ret);
+}
+
+void Float::inpad(Pad inpad) const {
+  if (H5Tset_inpad(static_cast<hid_t>(*this), static_cast<H5T_pad_t>(inpad)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype inpad to " << inpad;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
 } // namespace datatype
 } // namespace hdf5
-
-
-
-

--- a/src/h5cpp/datatype/float.hpp
+++ b/src/h5cpp/datatype/float.hpp
@@ -185,5 +185,23 @@ class DLL_EXPORT Float : public Datatype {
   virtual void inpad(Pad inpad) const;
 };
 
+
+class DLL_EXPORT float16_t{
+ private:
+  uint16_t _value; //!< data element holding the current float16 value
+ public:
+  //! default constructor
+  float16_t():_value(0) {}
+
+  //! conversion constructor
+  float16_t(uint16_t v):_value(v) {}
+
+  //! conversion operator
+  operator uint16_t() const {
+    return _value;
+  }
+};
+
+
 } // namespace datatype
 } // namespace hdf5

--- a/src/h5cpp/datatype/float.hpp
+++ b/src/h5cpp/datatype/float.hpp
@@ -191,7 +191,7 @@ class DLL_EXPORT float16_t{
   uint16_t _value; //!< data element holding the current float16 value
  public:
   //! default constructor
-  float16_t():_value(0) {}
+  float16_t():_value(0u) {}
 
   //! conversion constructor
   float16_t(uint16_t v):_value(v) {}

--- a/src/h5cpp/datatype/float.hpp
+++ b/src/h5cpp/datatype/float.hpp
@@ -22,12 +22,14 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 23, 2017
 //
 #pragma once
 
 #include <h5cpp/datatype/datatype.hpp>
 #include <h5cpp/core/windows.hpp>
+#include <vector>
 
 namespace hdf5 {
 namespace datatype {
@@ -60,6 +62,127 @@ class DLL_EXPORT Float : public Datatype {
   //! \param datatype reference to a generic datatype instance
   //!
   explicit Float(const Datatype &datatype);
+
+  //!
+  //! @brief get the precision of type, i.e. the number of significant bits
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual size_t precision() const;
+
+  //!
+  //! @brief set the precision of a type, i.e. the number of significant bits
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void precision(size_t precision) const;
+
+  //!
+  //! @brief get the bit offset of the first significant bit
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual size_t offset() const;
+
+  //!
+  //! @brief set the bit offset of the first significant bit
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void offset(size_t offset) const;
+
+  //!
+  //! @brief get the order of datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual Order order() const;
+
+  //!
+  //! @brief set the order of datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void order(Order order) const;
+
+  //!
+  //! @brief get the pads of datatype
+  //! @return least and most significant bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual const std::vector<Pad> pad() const;
+
+  //!
+  //! @brief set the pads of datatype
+  //!
+  //! @param lsb padding type for least-significant bits
+  //! @param msb padding type for most-significant bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void pad(Pad lsb, Pad msb) const;
+
+  //!
+  //! @brief get the floating point datatype bit field information
+  //! @return floating point datatype bit field information,
+  //!         i.e. floating-point sign bit, exponent bit-position, size of exponent in bits
+  //!              mantissa bit-position, size of mantissa in bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual const std::vector<size_t> fields() const;
+
+  //!
+  //! @brief set the floating point datatype bit field information
+  //!
+  //! @param spos  floating-point sign bit
+  //! @param epos  exponent bit-position
+  //! @param ssize size of exponent in bits
+  //! @param mpos  mantissa bit-position
+  //! @param msize size of mantissa in bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void fields(size_t spos, size_t epos, size_t esize, size_t mpos, size_t msize) const;
+
+  //!
+  //! @brief get the exponent bias of a floating-point type
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual size_t ebias() const;
+
+  //!
+  //! @brief set the exponent bias of a floating-point type
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void ebias(size_t ebias) const;
+
+  //!
+  //! @brief get the mantissa normalization of a floating-point datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual Norm norm() const;
+
+  //!
+  //! @brief set the mantissa normalization of a floating-point datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void norm(Norm norm) const;
+
+  //!
+  //! @brief get the internal padding type for unused bits in floating-point datatypes
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual Pad inpad() const;
+
+  //!
+  //! @brief set the internal padding type for unused bits in floating-point datatypes
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void inpad(Pad inpad) const;
 };
 
 } // namespace datatype

--- a/src/h5cpp/datatype/integer.cpp
+++ b/src/h5cpp/datatype/integer.cpp
@@ -62,5 +62,77 @@ void Integer::make_signed(bool sign) const {
   }
 }
 
+size_t Integer::precision() const {
+  size_t p = H5Tget_precision(static_cast<hid_t>(*this));
+  if (p == 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype precision");
+  }
+  return p;
+}
+
+void Integer::precision(size_t precision) const {
+  if (H5Tset_precision(static_cast<hid_t>(*this), precision) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype precision to " << precision;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+size_t Integer::offset() const {
+  ssize_t p = H5Tget_offset(static_cast<hid_t>(*this));
+  if (p < 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype offset");
+  }
+  return p;
+}
+
+void Integer::offset(size_t offset) const {
+  if (H5Tset_offset(static_cast<hid_t>(*this), offset) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype offset to " << offset;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+Order Integer::order() const {
+  htri_t ret = H5Tget_order(static_cast<hid_t>(*this));
+  if (ret > 4) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype order");
+  }
+  return static_cast<Order>(ret);
+}
+
+void Integer::order(Order order) const {
+  if (H5Tset_order(static_cast<hid_t>(*this), static_cast<H5T_order_t>(order)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype order to " << order;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
+
+const std::vector<Pad> Integer::pad() const {
+  H5T_pad_t lsb;
+  H5T_pad_t msb;
+  std::vector<Pad> pads(2);
+  htri_t ret = H5Tget_pad(static_cast<hid_t>(*this), &lsb, &msb);
+  if (ret < 0) {
+    error::Singleton::instance().throw_with_stack("Could not retrieve datatype order");
+  }
+  pads[0] = static_cast<Pad>(lsb);
+  pads[1] = static_cast<Pad>(msb);
+  return pads;
+}
+
+void Integer::pad(Pad lsb, Pad msb) const {
+  if (H5Tset_pad(static_cast<hid_t>(*this),
+		 static_cast<H5T_pad_t>(lsb),
+		 static_cast<H5T_pad_t>(msb)) < 0) {
+    std::stringstream ss;
+    ss << "Could not set datatype pad to (" << lsb << ", " << msb << ")" ;
+    error::Singleton::instance().throw_with_stack(ss.str());
+  }
+}
+
 } // namespace datatype
 } // namespace hdf5

--- a/src/h5cpp/datatype/integer.hpp
+++ b/src/h5cpp/datatype/integer.hpp
@@ -27,6 +27,7 @@
 //
 #pragma once
 
+#include <vector>
 #include <type_traits>
 #include <h5cpp/datatype/datatype.hpp>
 #include <h5cpp/core/windows.hpp>
@@ -90,7 +91,63 @@ class DLL_EXPORT Integer : public Datatype {
   //!
   virtual void make_signed(bool sign) const;
 
+  //!
+  //! @brief get the precision of type, i.e. the number of significant bits
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual size_t precision() const;
 
+  //!
+  //! @brief set the precision of a type, i.e. the number of significant bits
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void precision(size_t precision) const;
+
+  //!
+  //! @brief get the bit offset of the first significant bit
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual size_t offset() const;
+
+  //!
+  //! @brief set the bit offset of the first significant bit
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void offset(size_t offset) const;
+
+  //!
+  //! @brief get the order of datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual Order order() const;
+
+  //!
+  //! @brief set the order of datatype
+  //!
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void order(Order offset) const;
+
+  //!
+  //! @brief get the pads of datatype
+  //! @return least and most significant bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual const std::vector<Pad> pad() const;
+
+  //!
+  //! @brief set the pads of datatype
+  //!
+  //! @param lsb padding type for least-significant bits
+  //! @param msb padding type for most-significant bits
+  //! @throws std::runtime_error in case of a failure
+  //!
+  virtual void pad(Pad lsb, Pad msb) const;
 };
 
 } // namespace datatype

--- a/src/h5cpp/datatype/type_trait.hpp
+++ b/src/h5cpp/datatype/type_trait.hpp
@@ -21,6 +21,7 @@
 //
 // Authors: Eugen Wintersberger <eugen.wintersberger@desy.de>
 //          Sebastian Koenig <skoenig@ncsu.edu>
+//          Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 28, 2017
 //
 #pragma once

--- a/src/h5cpp/datatype/type_trait.hpp
+++ b/src/h5cpp/datatype/type_trait.hpp
@@ -175,6 +175,20 @@ class TypeTrait<unsigned long long> {
 };
 
 template<>
+class TypeTrait<datatype::float16_t> {
+ public:
+  using Type = datatype::float16_t;
+  using TypeClass = Float;
+  static TypeClass create(const Type & = Type()) {
+    auto type = TypeClass(ObjectHandle(H5Tcopy(H5T_NATIVE_FLOAT)));
+    type.fields(15, 10, 5, 0, 10);
+    type.size(2);
+    type.ebias(15);
+    return type;
+  }
+};
+
+template<>
 class TypeTrait<float> {
  public:
   using TypeClass = Float;

--- a/src/h5cpp/datatype/types.hpp
+++ b/src/h5cpp/datatype/types.hpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 23, 2017
 //
 #pragma once
@@ -73,7 +74,9 @@ DLL_EXPORT std::ostream &operator<<(std::ostream &stream, const Class &c);
 enum class Order : std::underlying_type<H5T_order_t>::type
 {
   LE = H5T_ORDER_LE, //!< littlen endian type
-  BE = H5T_ORDER_BE  //!< big endian type
+  BE = H5T_ORDER_BE,  //!< big endian type
+  VAX = H5T_ORDER_VAX, //  VAX mixed byte order
+  NONE = H5T_ORDER_NONE  // None
 };
 
 //!

--- a/test/datatype/float_test.cpp
+++ b/test/datatype/float_test.cpp
@@ -81,13 +81,13 @@ TYPED_TEST(Float, General) {
 
 TYPED_TEST(Float, Precision) {
   auto t = datatype::create<decltype(this->value_)>();
-  EXPECT_TRUE (t.precision() == t.size()*8 ||
-	       t.precision() == 80)
+  EXPECT_TRUE (t.precision() == t.size()*8lu ||
+	       t.precision() == 80lu)
     << "Where the precision value: "   << t.precision()
-    << " equals neither: " << t.size()*8
+    << " equals neither: " << t.size()*8lu
     << " nor: "               << 80 << ".";
   t.precision(80);
-  ASSERT_EQ(t.precision(), 80);
+  ASSERT_EQ(t.precision(), 80lu);
 }
 
 TYPED_TEST(Float, Order) {
@@ -107,11 +107,11 @@ TYPED_TEST(Float, Order) {
 
 TYPED_TEST(Float, Offset) {
   auto t = datatype::create<decltype(this->value_)>();
-  ASSERT_EQ(t.offset(), 0);
+  ASSERT_EQ(t.offset(), 0lu);
   t.offset(1);
-  ASSERT_EQ(t.offset(), 1);
+  ASSERT_EQ(t.offset(), 1lu);
   t.offset(2);
-  ASSERT_EQ(t.offset(), 2);
+  ASSERT_EQ(t.offset(), 2lu);
 }
 
 TYPED_TEST(Float, Pad) {
@@ -156,18 +156,18 @@ TYPED_TEST(Float, EBias) {
     << " equals neither: " << (2*t.size()*t.size()*t.size() - 1)
     << " nor: "            << (4*t.size()*t.size()*t.size() - 1) << ".";
   t.ebias(63);
-  ASSERT_EQ(t.ebias(), 63);
+  ASSERT_EQ(t.ebias(), 63lu);
   t.ebias(31);
-  ASSERT_EQ(t.ebias(), 31);
+  ASSERT_EQ(t.ebias(), 31lu);
 }
 
 TYPED_TEST(Float, Fields) {
-  std::vector<size_t> fields1({15, 10, 5, 0, 10});
-  std::vector<size_t> fields2({14, 9, 5, 0, 9});
+  std::vector<size_t> fields1({15lu, 10lu, 5lu, 0lu, 10lu});
+  std::vector<size_t> fields2({14lu, 9lu, 5lu, 0lu, 9lu});
   auto t = datatype::create<decltype(this->value_)>();
-  EXPECT_EQ (t.fields().size(), 5);
-  t.fields(15, 10, 5, 0, 10);
+  EXPECT_EQ (t.fields().size(), 5lu);
+  t.fields(15lu, 10lu, 5lu, 0lu, 10lu);
   ASSERT_EQ(t.fields(), fields1);
-  t.fields(14, 9, 5, 0, 9);
+  t.fields(14lu, 9lu, 5lu, 0lu, 9lu);
   ASSERT_EQ(t.fields(), fields2);
 }

--- a/test/datatype/float_test.cpp
+++ b/test/datatype/float_test.cpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 23, 2017
 //
 
@@ -43,7 +44,7 @@ using testing::Types;
 
 // The list of types we want to test.
 typedef
-Types<float, double, long double>
+Types<datatype::float16_t, float, double, long double>
     test_types;
 
 #ifdef TYPED_TEST_SUITE
@@ -75,4 +76,3 @@ TYPED_TEST(Float, General) {
   datatype::Datatype default_constructed;
   EXPECT_THROW((datatype::Float(default_constructed)), std::runtime_error);
 }
-

--- a/test/datatype/float_test.cpp
+++ b/test/datatype/float_test.cpp
@@ -47,8 +47,10 @@ typedef
 Types<datatype::float16_t, float, double, long double>
     test_types;
 
+// workaround for the TYPED_TEST_SUITE bug #2316
 #ifdef TYPED_TEST_SUITE
-TYPED_TEST_SUITE(Float, test_types);
+#include <gtest/internal/gtest-internal.h>
+TYPED_TEST_SUITE(Float, test_types, testing::internal::DefaultNameGenerator);
 #else
 TYPED_TEST_CASE(Float, test_types);
 #endif
@@ -75,4 +77,97 @@ TYPED_TEST(Float, General) {
   //cannot construct from an invalid type
   datatype::Datatype default_constructed;
   EXPECT_THROW((datatype::Float(default_constructed)), std::runtime_error);
+}
+
+TYPED_TEST(Float, Precision) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_TRUE (t.precision() == t.size()*8 ||
+	       t.precision() == 80)
+    << "Where the precision value: "   << t.precision()
+    << " equals neither: " << t.size()*8
+    << " nor: "               << 80 << ".";
+  t.precision(80);
+  ASSERT_EQ(t.precision(), 80);
+}
+
+TYPED_TEST(Float, Order) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_TRUE (t.order() == datatype::Order::LE ||
+	       t.order() == datatype::Order::BE ||
+	       t.order() == datatype::Order::VAX)
+    << "Where the order value: "   << t.order()
+    << " equals neither: " << datatype::Order::LE
+    << " nor: "               << datatype::Order::BE
+    << " nor: "               << datatype::Order::VAX << ".";
+  t.order(datatype::Order::BE);
+  ASSERT_EQ(t.order(), datatype::Order::BE);
+  t.order(datatype::Order::LE);
+  ASSERT_EQ(t.order(), datatype::Order::LE);
+}
+
+TYPED_TEST(Float, Offset) {
+  auto t = datatype::create<decltype(this->value_)>();
+  ASSERT_EQ(t.offset(), 0);
+  t.offset(1);
+  ASSERT_EQ(t.offset(), 1);
+  t.offset(2);
+  ASSERT_EQ(t.offset(), 2);
+}
+
+TYPED_TEST(Float, Pad) {
+  std::vector<datatype::Pad> pad00({datatype::Pad::ZERO, datatype::Pad::ZERO});
+  std::vector<datatype::Pad> pad01({datatype::Pad::ZERO, datatype::Pad::ONE});
+  std::vector<datatype::Pad> pad1B({datatype::Pad::ONE, datatype::Pad::BACKGROUND});
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_EQ (t.pad() , pad00);
+  t.pad(datatype::Pad::ZERO, datatype::Pad::ONE);
+  ASSERT_EQ(t.pad(), pad01);
+  t.pad(datatype::Pad::ONE, datatype::Pad::BACKGROUND);
+  ASSERT_EQ(t.pad(), pad1B);
+}
+
+TYPED_TEST(Float, Inpad) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_EQ (t.inpad() , datatype::Pad::ZERO);
+  t.inpad(datatype::Pad::ONE);
+  ASSERT_EQ(t.inpad(), datatype::Pad::ONE);
+  t.inpad(datatype::Pad::BACKGROUND);
+  ASSERT_EQ(t.inpad(), datatype::Pad::BACKGROUND);
+}
+
+TYPED_TEST(Float, Norm) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_TRUE (t.norm() == datatype::Norm::IMPLIED ||
+	       t.norm() == datatype::Norm::NONE)
+    << "Where the norm value: "   << t.norm()
+    << " equals neither: " << datatype::Norm::IMPLIED
+    << " nor: "               << datatype::Norm::NONE << ".";
+  t.norm(datatype::Norm::MSBSET);
+  ASSERT_EQ(t.norm(), datatype::Norm::MSBSET);
+  t.norm(datatype::Norm::NONE);
+  ASSERT_EQ(t.norm(), datatype::Norm::NONE);
+}
+
+TYPED_TEST(Float, EBias) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_TRUE (t.ebias() == 2*t.size()*t.size()*t.size() - 1 ||
+	       t.ebias() == 4*t.size()*t.size()*t.size() - 1)
+    << "Where the ebias value: "   << t.ebias()
+    << " equals neither: " << (2*t.size()*t.size()*t.size() - 1)
+    << " nor: "            << (4*t.size()*t.size()*t.size() - 1) << ".";
+  t.ebias(63);
+  ASSERT_EQ(t.ebias(), 63);
+  t.ebias(31);
+  ASSERT_EQ(t.ebias(), 31);
+}
+
+TYPED_TEST(Float, Fields) {
+  std::vector<size_t> fields1({15, 10, 5, 0, 10});
+  std::vector<size_t> fields2({14, 9, 5, 0, 9});
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_EQ (t.fields().size(), 5);
+  t.fields(15, 10, 5, 0, 10);
+  ASSERT_EQ(t.fields(), fields1);
+  t.fields(14, 9, 5, 0, 9);
+  ASSERT_EQ(t.fields(), fields2);
 }

--- a/test/datatype/integer_test.cpp
+++ b/test/datatype/integer_test.cpp
@@ -71,10 +71,12 @@ Types<
 typedef
 Types<signed char, short, int, long, long long> test_signed_types;
 
+// workaround for the TYPED_TEST_SUITE bug #2316
 #ifdef TYPED_TEST_SUITE
-TYPED_TEST_SUITE(Integer, test_types);
-TYPED_TEST_SUITE(SignedInteger, test_signed_types);
-TYPED_TEST_SUITE(UnsignedInteger, test_unsigned_types);
+#include <gtest/internal/gtest-internal.h>
+TYPED_TEST_SUITE(Integer, test_types, testing::internal::DefaultNameGenerator);
+TYPED_TEST_SUITE(SignedInteger, test_signed_types, testing::internal::DefaultNameGenerator);
+TYPED_TEST_SUITE(UnsignedInteger, test_unsigned_types, testing::internal::DefaultNameGenerator);
 #else
 TYPED_TEST_CASE(Integer, test_types);
 TYPED_TEST_CASE(SignedInteger, test_signed_types);
@@ -106,7 +108,7 @@ TYPED_TEST(Integer, General) {
 
 TYPED_TEST(SignedInteger, Signed) {
   auto t = datatype::create<decltype(this->value_)>();
-  
+
   ASSERT_EQ(t.is_signed(), true);
   t.make_signed(true);
   ASSERT_EQ(t.is_signed(), true);
@@ -116,7 +118,7 @@ TYPED_TEST(SignedInteger, Signed) {
 
 TYPED_TEST(UnsignedInteger, Signed) {
   auto t = datatype::create<decltype(this->value_)>();
-  
+
   ASSERT_EQ(t.is_signed(), false);
   t.make_signed(true);
   ASSERT_EQ(t.is_signed(), true);
@@ -124,3 +126,47 @@ TYPED_TEST(UnsignedInteger, Signed) {
   ASSERT_EQ(t.is_signed(), false);
 }
 
+TYPED_TEST(Integer, Precision) {
+  auto t = datatype::create<decltype(this->value_)>();
+  ASSERT_EQ(t.precision(), t.size()*8);
+  t.precision(16);
+  ASSERT_EQ(t.precision(), 16);
+  t.precision(8);
+  ASSERT_EQ(t.precision(), 8);
+}
+
+TYPED_TEST(Integer, Order) {
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_TRUE (t.order() == datatype::Order::LE ||
+	       t.order() == datatype::Order::BE ||
+	       t.order() == datatype::Order::VAX)
+    << "Where the order value: "   << t.order()
+    << " equals neither: " << datatype::Order::LE
+    << " nor: "               << datatype::Order::BE
+    << " nor: "               << datatype::Order::VAX << ".";
+  t.order(datatype::Order::BE);
+  ASSERT_EQ(t.order(), datatype::Order::BE);
+  t.order(datatype::Order::LE);
+  ASSERT_EQ(t.order(), datatype::Order::LE);
+}
+
+TYPED_TEST(Integer, Offset) {
+  auto t = datatype::create<decltype(this->value_)>();
+  ASSERT_EQ(t.offset(), 0);
+  t.offset(1);
+  ASSERT_EQ(t.offset(), 1);
+  t.offset(2);
+  ASSERT_EQ(t.offset(), 2);
+}
+
+TYPED_TEST(Integer, Pad) {
+  std::vector<datatype::Pad> pad00({datatype::Pad::ZERO, datatype::Pad::ZERO});
+  std::vector<datatype::Pad> pad01({datatype::Pad::ZERO, datatype::Pad::ONE});
+  std::vector<datatype::Pad> pad1B({datatype::Pad::ONE, datatype::Pad::BACKGROUND});
+  auto t = datatype::create<decltype(this->value_)>();
+  EXPECT_EQ (t.pad() , pad00);
+  t.pad(datatype::Pad::ZERO, datatype::Pad::ONE);
+  ASSERT_EQ(t.pad(), pad01);
+  t.pad(datatype::Pad::ONE, datatype::Pad::BACKGROUND);
+  ASSERT_EQ(t.pad(), pad1B);
+}

--- a/test/datatype/integer_test.cpp
+++ b/test/datatype/integer_test.cpp
@@ -128,11 +128,11 @@ TYPED_TEST(UnsignedInteger, Signed) {
 
 TYPED_TEST(Integer, Precision) {
   auto t = datatype::create<decltype(this->value_)>();
-  ASSERT_EQ(t.precision(), t.size()*8);
-  t.precision(16);
-  ASSERT_EQ(t.precision(), 16);
-  t.precision(8);
-  ASSERT_EQ(t.precision(), 8);
+  ASSERT_EQ(t.precision(), t.size()*8lu);
+  t.precision(16lu);
+  ASSERT_EQ(t.precision(), 16lu);
+  t.precision(8lu);
+  ASSERT_EQ(t.precision(), 8lu);
 }
 
 TYPED_TEST(Integer, Order) {
@@ -152,11 +152,11 @@ TYPED_TEST(Integer, Order) {
 
 TYPED_TEST(Integer, Offset) {
   auto t = datatype::create<decltype(this->value_)>();
-  ASSERT_EQ(t.offset(), 0);
+  ASSERT_EQ(t.offset(), 0lu);
   t.offset(1);
-  ASSERT_EQ(t.offset(), 1);
+  ASSERT_EQ(t.offset(), 1lu);
   t.offset(2);
-  ASSERT_EQ(t.offset(), 2);
+  ASSERT_EQ(t.offset(), 2lu);
 }
 
 TYPED_TEST(Integer, Pad) {

--- a/test/datatype/string_test.cpp
+++ b/test/datatype/string_test.cpp
@@ -66,8 +66,10 @@ Types<std::string>
 //std::u32string>
     test_types;
 
+// workaround for the TYPED_TEST_SUITE bug #2316
 #ifdef TYPED_TEST_SUITE
-TYPED_TEST_SUITE(String, test_types);
+#include <gtest/internal/gtest-internal.h>
+TYPED_TEST_SUITE(String, test_types, testing::internal::DefaultNameGenerator);
 #else
 TYPED_TEST_CASE(String, test_types);
 #endif

--- a/test/node/dataset_h5py_string_compat_test.cpp
+++ b/test/node/dataset_h5py_string_compat_test.cpp
@@ -62,7 +62,7 @@ TEST_F(H5pyStringCompatTest, test_read_scalar_string_utf8)
   dataset.read(buffer, datatype, dataspace);
   // 'Hello UTF8! Pr\xf3ba \u6d4b'
   const std::string su = "Hello UTF8! Pr""\xc3""\xb3""ba ""\xe6""\xb5""\x8b";
-  EXPECT_EQ(buffer.size(), 1);
+  EXPECT_EQ(buffer.size(), 1lu);
   EXPECT_EQ(buffer[0], su);
 }
 
@@ -74,7 +74,7 @@ TEST_F(H5pyStringCompatTest, test_read_scalar_string_simple_utf8)
 
   // 'Hello UTF8! Pr\xf3ba \u6d4b'
   const std::string su = "Hello UTF8! Pr""\xc3""\xb3""ba ""\xe6""\xb5""\x8b";
-  EXPECT_EQ(buffer.size(), 1);
+  EXPECT_EQ(buffer.size(), 1lu);
   EXPECT_EQ(buffer[0], su);
 }
 


### PR DESCRIPTION
It resolves #434 by adding float16_t type and  missing datatype properties i.e.
- Integer -  precision, offset, order, pad
- Float -  precision, offset, order, pad, inpad, norm, ebias, fields

The properties `precision` and `offset` are very useful for NBit filter whille `fields` and `ebias` are used in creating of a new type examples i.e. `float16_t`.