### PR TITLE
Issue 389: add NBit, SZip and ScaleOffset filters

### DIFF
--- a/src/h5cpp/filter/CMakeLists.txt
+++ b/src/h5cpp/filter/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
   ${dir}/deflate.cpp
   ${dir}/filter.cpp
   ${dir}/fletcher32.cpp
+  ${dir}/nbit.cpp
   ${dir}/shuffle.cpp
   ${dir}/external_filter.cpp
   )
@@ -13,6 +14,7 @@ set(HEADERS
   ${dir}/types.hpp
   ${dir}/deflate.hpp
   ${dir}/fletcher32.hpp
+  ${dir}/nbit.hpp
   ${dir}/shuffle.hpp
   ${dir}/external_filter.hpp
   )

--- a/src/h5cpp/filter/CMakeLists.txt
+++ b/src/h5cpp/filter/CMakeLists.txt
@@ -5,7 +5,9 @@ set(SOURCES
   ${dir}/filter.cpp
   ${dir}/fletcher32.cpp
   ${dir}/nbit.cpp
+  ${dir}/scaleoffset.cpp
   ${dir}/shuffle.cpp
+  ${dir}/szip.cpp
   ${dir}/external_filter.cpp
   )
 
@@ -15,7 +17,9 @@ set(HEADERS
   ${dir}/deflate.hpp
   ${dir}/fletcher32.hpp
   ${dir}/nbit.hpp
+  ${dir}/scaleoffset.hpp
   ${dir}/shuffle.hpp
+  ${dir}/szip.hpp
   ${dir}/external_filter.hpp
   )
 

--- a/src/h5cpp/filter/external_filter.cpp
+++ b/src/h5cpp/filter/external_filter.cpp
@@ -85,19 +85,12 @@ const std::vector<Availability> ExternalFilters::fill(const property::DatasetCre
 						      size_t max_name_size)
 {
   std::vector<Availability> flags;
-  int nfilters = H5Pget_nfilters(static_cast<hid_t>(dcpl));
-  if(nfilters < 0)
-  {
-      std::stringstream ss;
-      ss<<"Failure to read a number of filters from " << dcpl.get_class();
-      error::Singleton::instance().throw_with_stack(ss.str());
-  }
-
+  size_t nfilters = dcpl.nfilters();
   unsigned int flag;
   size_t cd_number = max_cd_number;
   std::vector<char> fname(max_name_size);
 
-  for(int nf=0; nf != nfilters; nf++)
+  for(size_t nf=0; nf != nfilters; nf++)
   {
     std::vector<unsigned int> cd_values(max_cd_number);
     int filter_id = H5Pget_filter(static_cast<hid_t>(dcpl),
@@ -108,7 +101,7 @@ const std::vector<Availability> ExternalFilters::fill(const property::DatasetCre
 			      fname.size(),
 			      fname.data(),
 			      NULL);
-    if(nfilters < 0)
+    if(filter_id < 0)
     {
       std::stringstream ss;
       ss << "Failure to read a parameters of filter ("

--- a/src/h5cpp/filter/external_filter.cpp
+++ b/src/h5cpp/filter/external_filter.cpp
@@ -90,7 +90,7 @@ const std::vector<Availability> ExternalFilters::fill(const property::DatasetCre
   size_t cd_number = max_cd_number;
   std::vector<char> fname(max_name_size);
 
-  for(size_t nf=0; nf != nfilters; nf++)
+  for(unsigned int nf=0; nf != nfilters; nf++)
   {
     std::vector<unsigned int> cd_values(max_cd_number);
     int filter_id = H5Pget_filter(static_cast<hid_t>(dcpl),

--- a/src/h5cpp/filter/filter.cpp
+++ b/src/h5cpp/filter/filter.cpp
@@ -53,7 +53,7 @@ bool Filter::is_encoding_enabled() const
     ss<<"Configuration flag cannot be checked for filter: " << id_;
     error::Singleton::instance().throw_with_stack(ss.str());
   }
-  
+
   return  bool(filter_info & H5Z_FILTER_CONFIG_ENCODE_ENABLED);
 }
 
@@ -66,7 +66,7 @@ bool Filter::is_decoding_enabled() const
     ss<<"Configuration flag cannot be checked for filter: " << id_;
     error::Singleton::instance().throw_with_stack(ss.str());
   }
-  
+
   return  bool(filter_info & H5Z_FILTER_CONFIG_DECODE_ENABLED);
 }
 

--- a/src/h5cpp/filter/filter.hpp
+++ b/src/h5cpp/filter/filter.hpp
@@ -74,6 +74,20 @@ class DLL_EXPORT Filter
     //!
     FilterID id() const noexcept;
 
+    //!
+    //! \brief get the the config flag if encoding enabled
+    //!
+    //! Return the actual config encoding enabled flag of the filter.
+    //!
+    virtual bool is_encoding_enabled() const;
+  
+    //!
+    //! \brief get the the config flag if decoding enabled
+    //!
+    //! Return the actual config decoding enabled flag of the filter.
+    //!
+    virtual bool is_decoding_enabled() const;
+
   protected:
     //!
     //! \brief construtor

--- a/src/h5cpp/filter/filter.hpp
+++ b/src/h5cpp/filter/filter.hpp
@@ -80,7 +80,7 @@ class DLL_EXPORT Filter
     //! Return the actual config encoding enabled flag of the filter.
     //!
     virtual bool is_encoding_enabled() const;
-  
+
     //!
     //! \brief get the the config flag if decoding enabled
     //!

--- a/src/h5cpp/filter/meson.build
+++ b/src/h5cpp/filter/meson.build
@@ -1,6 +1,6 @@
-sources+=files('deflate.cpp', 'filter.cpp', 'fletcher32.cpp',
+sources+=files('deflate.cpp', 'filter.cpp', 'fletcher32.cpp', 'nbit.cpp',
                'shuffle.cpp', 'external_filter.cpp')
-local_headers=files('filter.hpp', 'types.hpp', 'deflate.hpp',
+local_headers=files('filter.hpp', 'types.hpp', 'deflate.hpp', 'nbit.hpp',
                     'fletcher32.hpp', 'shuffle.hpp',
                     'external_filter.hpp')
 headers+=local_headers

--- a/src/h5cpp/filter/meson.build
+++ b/src/h5cpp/filter/meson.build
@@ -1,7 +1,7 @@
 sources+=files('deflate.cpp', 'filter.cpp', 'fletcher32.cpp', 'nbit.cpp',
-               'shuffle.cpp', 'external_filter.cpp')
+               'scaleoffset.cpp', 'shuffle.cpp', 'szip.cpp', 'external_filter.cpp')
 local_headers=files('filter.hpp', 'types.hpp', 'deflate.hpp', 'nbit.hpp',
-                    'fletcher32.hpp', 'shuffle.hpp',
+                    'fletcher32.hpp',  'scaleoffset.cpp', 'shuffle.hpp', 'szip.hpp',
                     'external_filter.hpp')
 headers+=local_headers
 

--- a/src/h5cpp/filter/nbit.cpp
+++ b/src/h5cpp/filter/nbit.cpp
@@ -1,0 +1,51 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+
+#include <h5cpp/filter/nbit.hpp>
+#include <h5cpp/error/error.hpp>
+
+namespace hdf5 {
+namespace filter {
+
+NBit::NBit():
+    Filter(H5Z_FILTER_NBIT)
+{}
+
+NBit::~NBit()
+{}
+
+void NBit::operator()(const property::DatasetCreationList &dcpl,
+                            Availability) const
+{
+  if(H5Pset_nbit(static_cast<hid_t>(dcpl))<0)
+  {
+    error::Singleton::instance().throw_with_stack("Failure to set the nbit filter!");
+  }
+}
+
+} // namespace filter
+} // namespace hdf5

--- a/src/h5cpp/filter/nbit.hpp
+++ b/src/h5cpp/filter/nbit.hpp
@@ -19,56 +19,45 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
-// Created on: Nov 6, 2017
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
 //
+#pragma once
 
 #include <h5cpp/filter/filter.hpp>
 
 namespace hdf5 {
 namespace filter {
 
-Filter::Filter():
-    id_(H5Z_FILTER_NONE)
-{}
-
-Filter::Filter(FilterID id):
-    id_(id)
-{}
-
-Filter::~Filter()
-{}
-
-FilterID Filter::id() const noexcept
+//!
+//! \brief NBit checksum filter
+//!
+//! If applied to a dataset creation property list this filter will setup
+//! the nbit checksum filter.
+//!
+class DLL_EXPORT NBit : public Filter
 {
-  return id_;
-}
+  public:
+    //!
+    //! \brief default constructor
+    //!
+    NBit();
 
-bool Filter::is_encoding_enabled() const
-{
-  unsigned int filter_info;
-  if(H5Zget_filter_info(id_, &filter_info) < 0)
-  {
-    std::stringstream ss;
-    ss<<"Configuration flag cannot be checked for filter: " << id_;
-    error::Singleton::instance().throw_with_stack(ss.str());
-  }
-  
-  return  bool(filter_info & H5Z_FILTER_CONFIG_ENCODE_ENABLED);
-}
+    ~NBit();
 
-bool Filter::is_decoding_enabled() const
-{
-  unsigned int filter_info;
-  if(H5Zget_filter_info(id_, &filter_info) < 0)
-  {
-    std::stringstream ss;
-    ss<<"Configuration flag cannot be checked for filter: " << id_;
-    error::Singleton::instance().throw_with_stack(ss.str());
-  }
-  
-  return  bool(filter_info & H5Z_FILTER_CONFIG_DECODE_ENABLED);
-}
+    //!
+    //! \brief apply filter
+    //!
+    //! Applies the filter to a dataset creation property list.
+    //!
+    //! \throws std::runtime_error in case of a failure
+    //! \param dcpl reference to the dataset creation property list
+    //!
+    virtual void operator()(const property::DatasetCreationList &dcpl,
+                            Availability flag = Availability::MANDATORY) const;
+};
 
 } // namespace filter
-} // namesapce hdf5
+} // namespace hdf5

--- a/src/h5cpp/filter/scaleoffset.cpp
+++ b/src/h5cpp/filter/scaleoffset.cpp
@@ -1,0 +1,90 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+
+#include <h5cpp/core/hdf5_capi.hpp>
+#include <h5cpp/filter/scaleoffset.hpp>
+#include <h5cpp/error/error.hpp>
+#include <sstream>
+
+namespace hdf5 {
+namespace filter {
+
+ScaleOffset::ScaleOffset():
+    Filter(H5Z_FILTER_SCALEOFFSET),
+    scale_type_(SOScaleType::FLOAT_DSCALE),
+    scale_factor_(1)
+{}
+
+ScaleOffset::ScaleOffset(SOScaleType scale_type, int scale_factor):
+    Filter(H5Z_FILTER_SCALEOFFSET),
+    scale_type_(scale_type),
+    scale_factor_(scale_factor)
+{}
+
+ScaleOffset::~ScaleOffset()
+{}
+
+SOScaleType ScaleOffset::scale_type() const noexcept
+{
+  return scale_type_;
+}
+
+void ScaleOffset::scale_type(SOScaleType scale_type)
+{
+  scale_type_ = scale_type;
+}
+
+int ScaleOffset::scale_factor() const noexcept
+{
+  return scale_factor_;
+}
+
+void ScaleOffset::scale_factor(int scale_factor)
+{
+  scale_factor_ = scale_factor;
+}
+
+void ScaleOffset::operator()(const property::DatasetCreationList &dcpl,
+                         Availability) const
+{
+  if(H5Pset_scaleoffset(static_cast<hid_t>(dcpl), static_cast<H5Z_SO_scale_type_t>(scale_type_), scale_factor_)<0)
+  {
+    error::Singleton::instance().throw_with_stack("Could not apply ScaleOffset filter!");
+  }
+}
+
+std::ostream &operator<<(std::ostream &stream, const SOScaleType &scale_type) {
+  switch (scale_type) {
+    case SOScaleType::FLOAT_DSCALE: return stream << "FLOAT_DSCALE";
+    case SOScaleType::FLOAT_ESCALE: return stream << "FLOAT_ESCALE";
+    case SOScaleType::INT: return stream << "INT";
+    default:return stream;
+  }
+}
+
+} // namespace filter
+} // namespace hdf5

--- a/src/h5cpp/filter/scaleoffset.hpp
+++ b/src/h5cpp/filter/scaleoffset.hpp
@@ -1,0 +1,85 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+#pragma once
+
+#include <iostream>
+#include <h5cpp/filter/filter.hpp>
+
+namespace hdf5 {
+namespace filter {
+
+
+//!
+//! @brief character set encoding
+//!
+//! Enumeration type determining the character encoding used by string types
+//! and links.
+//!
+enum class SOScaleType: std::underlying_type<H5Z_SO_scale_type_t>::type {
+  FLOAT_DSCALE = H5Z_SO_FLOAT_DSCALE,  // Floating-point type, using variable MinBits method
+  FLOAT_ESCALE = H5Z_SO_FLOAT_ESCALE,  // Floating-point type, using fixed MinBits method
+  INT = H5Z_SO_INT                     // Integer type
+};
+
+
+class DLL_EXPORT ScaleOffset : public Filter
+{
+  private:
+    SOScaleType scale_type_;
+    int scale_factor_;
+  public:
+    ScaleOffset();
+    ScaleOffset(SOScaleType scale_type, int scale_factor_);
+    ~ScaleOffset();
+
+    SOScaleType scale_type() const noexcept;
+
+    void scale_type(SOScaleType scale_type);
+
+    int scale_factor() const noexcept;
+
+    void scale_factor(int scale_factor);
+
+    virtual void operator()(const property::DatasetCreationList &dcpl,
+                            Availability flag=Availability::MANDATORY) const;
+
+};
+
+
+
+//!
+//! @brief stream output operator for CharacterEncoding enumerations
+//!
+//! @param stream reference to an output stream
+//! @param enc reference to a CharacterEncoding enumeration instance
+//! @return modified output stream
+//!
+DLL_EXPORT std::ostream &operator<<(std::ostream &stream, const SOScaleType &scale_type);
+
+
+} // namespace filter
+} // namespace hdf5

--- a/src/h5cpp/filter/szip.cpp
+++ b/src/h5cpp/filter/szip.cpp
@@ -1,0 +1,85 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+
+#include <h5cpp/core/hdf5_capi.hpp>
+#include <h5cpp/filter/szip.hpp>
+#include <h5cpp/error/error.hpp>
+#include <sstream>
+
+namespace hdf5 {
+namespace filter {
+
+SZip::SZip():
+    Filter(H5Z_FILTER_SZIP),
+    options_mask_(32),
+    pixels_per_block_(0)
+{}
+
+SZip::SZip(unsigned int options_mask, unsigned int pixels_per_block):
+    Filter(H5Z_FILTER_SZIP),
+    options_mask_(options_mask),
+    pixels_per_block_(pixels_per_block)
+{}
+
+SZip::~SZip()
+{}
+
+unsigned int SZip::options_mask() const noexcept
+{
+  return options_mask_;
+}
+
+void SZip::options_mask(unsigned int options_mask)
+{
+  options_mask_ = options_mask;
+}
+
+unsigned int SZip::pixels_per_block() const noexcept
+{
+  return pixels_per_block_;
+}
+
+void SZip::pixels_per_block(unsigned int pixels_per_block)
+{
+  pixels_per_block_ = pixels_per_block;
+}
+
+void SZip::operator()(const property::DatasetCreationList &dcpl,
+                         Availability) const
+{
+  if(H5Pset_szip(static_cast<hid_t>(dcpl), options_mask_, pixels_per_block_)<0)
+  {
+    error::Singleton::instance().throw_with_stack("Could not apply SZip filter!");
+  }
+}
+
+const unsigned int SZip::EC_OPTION_MASK = H5_SZIP_EC_OPTION_MASK;
+const unsigned int SZip::NN_OPTION_MASK = H5_SZIP_NN_OPTION_MASK;
+
+
+} // namespace filter
+} // namespace hdf5

--- a/src/h5cpp/filter/szip.hpp
+++ b/src/h5cpp/filter/szip.hpp
@@ -54,9 +54,9 @@ class DLL_EXPORT SZip : public Filter
 
     // Selects entropy coding method
     static const unsigned int EC_OPTION_MASK;
-    // Selects nearest neighbor coding method. 
+    // Selects nearest neighbor coding method.
     static const unsigned int NN_OPTION_MASK;
 };
-  
+
 } // namespace filter
 } // namespace hdf5

--- a/src/h5cpp/filter/szip.hpp
+++ b/src/h5cpp/filter/szip.hpp
@@ -1,0 +1,62 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+#pragma once
+
+#include <h5cpp/filter/filter.hpp>
+
+namespace hdf5 {
+namespace filter {
+
+class DLL_EXPORT SZip : public Filter
+{
+  private:
+    unsigned int options_mask_;
+    unsigned int pixels_per_block_;
+  public:
+    SZip();
+    SZip(unsigned int options_mask, unsigned int pixels_per_block);
+    ~SZip();
+
+    unsigned int options_mask() const noexcept;
+
+    void options_mask(unsigned int options_mask);
+
+    unsigned int pixels_per_block() const noexcept;
+
+    void pixels_per_block(unsigned int pixels_per_block);
+
+    virtual void operator()(const property::DatasetCreationList &dcpl,
+                            Availability flag=Availability::MANDATORY) const;
+
+    // Selects entropy coding method
+    static const unsigned int EC_OPTION_MASK;
+    // Selects nearest neighbor coding method. 
+    static const unsigned int NN_OPTION_MASK;
+};
+  
+} // namespace filter
+} // namespace hdf5

--- a/src/h5cpp/hdf5.hpp
+++ b/src/h5cpp/hdf5.hpp
@@ -80,7 +80,9 @@
 #include <h5cpp/filter/deflate.hpp>
 #include <h5cpp/filter/fletcher32.hpp>
 #include <h5cpp/filter/nbit.hpp>
+#include <h5cpp/filter/scaleoffset.hpp>
 #include <h5cpp/filter/shuffle.hpp>
+#include <h5cpp/filter/szip.hpp>
 #include <h5cpp/filter/external_filter.hpp>
 
 #include <h5cpp/node/dataset.hpp>

--- a/src/h5cpp/hdf5.hpp
+++ b/src/h5cpp/hdf5.hpp
@@ -79,6 +79,7 @@
 #include <h5cpp/filter/types.hpp>
 #include <h5cpp/filter/deflate.hpp>
 #include <h5cpp/filter/fletcher32.hpp>
+#include <h5cpp/filter/nbit.hpp>
 #include <h5cpp/filter/shuffle.hpp>
 #include <h5cpp/filter/external_filter.hpp>
 

--- a/src/h5cpp/property/dataset_creation.cpp
+++ b/src/h5cpp/property/dataset_creation.cpp
@@ -163,5 +163,18 @@ DatasetAllocTime DatasetCreationList::allocation_time() const {
   return static_cast<DatasetAllocTime>(buffer);
 }
 
+size_t DatasetCreationList::nfilters() const{
+  int nfilters = H5Pget_nfilters(static_cast<hid_t>(*this));
+  if(nfilters < 0)
+  {
+      std::stringstream ss;
+      ss<<"Failure to read a number of filters from " << this->get_class();
+      error::Singleton::instance().throw_with_stack(ss.str());
+  }
+  return static_cast<size_t>(nfilters);
+  
+}
+
+  
 } // namespace property
 } // namespace hdf5

--- a/src/h5cpp/property/dataset_creation.cpp
+++ b/src/h5cpp/property/dataset_creation.cpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Aug 25, 2017
 //
 #include <h5cpp/property/property_class.hpp>
@@ -163,7 +164,7 @@ DatasetAllocTime DatasetCreationList::allocation_time() const {
   return static_cast<DatasetAllocTime>(buffer);
 }
 
-size_t DatasetCreationList::nfilters() const{
+unsigned int DatasetCreationList::nfilters() const{
   int nfilters = H5Pget_nfilters(static_cast<hid_t>(*this));
   if(nfilters < 0)
   {
@@ -171,10 +172,10 @@ size_t DatasetCreationList::nfilters() const{
       ss<<"Failure to read a number of filters from " << this->get_class();
       error::Singleton::instance().throw_with_stack(ss.str());
   }
-  return static_cast<size_t>(nfilters);
-  
+  return static_cast<unsigned int>(nfilters);
+
 }
 
-  
+
 } // namespace property
 } // namespace hdf5

--- a/src/h5cpp/property/dataset_creation.hpp
+++ b/src/h5cpp/property/dataset_creation.hpp
@@ -224,11 +224,11 @@ class DLL_EXPORT DatasetCreationList : public ObjectCreationList {
   //! \sa allocation_time(DatasetAllocTime)
   //!
   DatasetAllocTime allocation_time() const;
-  
+
   //!
   //! \brief get a number of filters
   //!
-  size_t nfilters() const;
+  unsigned int nfilters() const;
 };
 
 template<typename T>

--- a/src/h5cpp/property/dataset_creation.hpp
+++ b/src/h5cpp/property/dataset_creation.hpp
@@ -224,6 +224,11 @@ class DLL_EXPORT DatasetCreationList : public ObjectCreationList {
   //! \sa allocation_time(DatasetAllocTime)
   //!
   DatasetAllocTime allocation_time() const;
+  
+  //!
+  //! \brief get a number of filters
+  //!
+  size_t nfilters() const;
 };
 
 template<typename T>

--- a/test/filter/CMakeLists.txt
+++ b/test/filter/CMakeLists.txt
@@ -3,7 +3,9 @@ set(dir ${CMAKE_CURRENT_SOURCE_DIR})
 set(test_sources
   ${test_sources}
   ${dir}/deflate_test.cpp
+  ${dir}/scaleoffset_test.cpp
   ${dir}/shuffle_test.cpp
+  ${dir}/szip_test.cpp
   ${dir}/fletcher32_test.cpp
   ${dir}/nbit_test.cpp
   ${dir}/external_filter_test.cpp

--- a/test/filter/CMakeLists.txt
+++ b/test/filter/CMakeLists.txt
@@ -5,5 +5,6 @@ set(test_sources
   ${dir}/deflate_test.cpp
   ${dir}/shuffle_test.cpp
   ${dir}/fletcher32_test.cpp
+  ${dir}/nbit_test.cpp
   ${dir}/external_filter_test.cpp
   PARENT_SCOPE)

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -71,7 +71,7 @@ TEST(ExternalFilterTest, deflate_application)
   filter::ExternalFilters filters;
   auto flags = filters.fill(dcpl);
   // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
-  EXPECT_EQ(dcpl.nfilters(), 1lu);
+  EXPECT_EQ(dcpl.nfilters(), 1u);
   EXPECT_EQ(filters.size(), 1lu);
   EXPECT_EQ(flags.size(), 1lu);
   EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
@@ -96,7 +96,7 @@ TEST(ExternalFilterTest, deflate_shuffle_application)
   // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
   EXPECT_EQ(filters.size(), 2lu);
   EXPECT_EQ(flags.size(), 2lu);
-  EXPECT_EQ(dcpl.nfilters(), 2lu);
+  EXPECT_EQ(dcpl.nfilters(), 2u);
   EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
   EXPECT_EQ(flags[1], filter::Availability::OPTIONAL);
   EXPECT_EQ(filters[0].cd_values(), cdvalues);

--- a/test/filter/external_filter_test.cpp
+++ b/test/filter/external_filter_test.cpp
@@ -71,6 +71,7 @@ TEST(ExternalFilterTest, deflate_application)
   filter::ExternalFilters filters;
   auto flags = filters.fill(dcpl);
   // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+  EXPECT_EQ(dcpl.nfilters(), 1lu);
   EXPECT_EQ(filters.size(), 1lu);
   EXPECT_EQ(flags.size(), 1lu);
   EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
@@ -95,12 +96,17 @@ TEST(ExternalFilterTest, deflate_shuffle_application)
   // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
   EXPECT_EQ(filters.size(), 2lu);
   EXPECT_EQ(flags.size(), 2lu);
+  EXPECT_EQ(dcpl.nfilters(), 2lu);
   EXPECT_EQ(flags[0], filter::Availability::MANDATORY);
   EXPECT_EQ(flags[1], filter::Availability::OPTIONAL);
   EXPECT_EQ(filters[0].cd_values(), cdvalues);
   EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_DEFLATE));
   EXPECT_EQ(filters[0].name(), "deflate");
+  EXPECT_EQ(filters[0].is_decoding_enabled(), true);
+  EXPECT_EQ(filters[0].is_encoding_enabled(), true);
   EXPECT_EQ(filters[1].cd_values(), cdvalues2);
   EXPECT_EQ(filters[1].id(), static_cast<int>(H5Z_FILTER_SHUFFLE));
+  EXPECT_EQ(filters[1].is_decoding_enabled(), true);
+  EXPECT_EQ(filters[1].is_encoding_enabled(), true);
   EXPECT_EQ(filters[1].name(), "shuffle");
 }

--- a/test/filter/meson.build
+++ b/test/filter/meson.build
@@ -1,4 +1,5 @@
 test_sources+=files('deflate_test.cpp',
                     'shuffle_test.cpp',
                     'fletcher32_test.cpp',
+                    'nbit_test.cpp',
                     'external_filter_test.cpp')

--- a/test/filter/meson.build
+++ b/test/filter/meson.build
@@ -1,5 +1,7 @@
 test_sources+=files('deflate_test.cpp',
+		    'scaleoffset_test.cpp',
                     'shuffle_test.cpp',
+		    'szip_test.cpp',
                     'fletcher32_test.cpp',
                     'nbit_test.cpp',
                     'external_filter_test.cpp')

--- a/test/filter/nbit_test.cpp
+++ b/test/filter/nbit_test.cpp
@@ -1,0 +1,64 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+#include <gtest/gtest.h>
+#include <h5cpp/hdf5.hpp>
+
+using namespace hdf5;
+
+TEST(NBitTest,construction)
+{
+  filter::NBit filter;
+  EXPECT_EQ(filter.id(),H5Z_FILTER_NBIT);
+}
+
+TEST(NBitTest,application)
+{
+  filter::NBit filter;
+  property::DatasetCreationList dcpl;
+
+  filter(dcpl);
+  filter::ExternalFilters filters;
+  auto flags = filters.fill(dcpl);
+  std::vector<unsigned int> cdvalues({});
+  if(filter::is_filter_available(H5Z_FILTER_NBIT)){
+    // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+    EXPECT_EQ(filter.id(), static_cast<int>(H5Z_FILTER_NBIT));
+    EXPECT_EQ(filter.is_decoding_enabled(), true);
+    EXPECT_EQ(filter.is_encoding_enabled(), true);
+    EXPECT_EQ(dcpl.nfilters(), 1lu);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(flags.size(), 1lu);
+    EXPECT_EQ(flags[0], filter::Availability::OPTIONAL);
+    EXPECT_EQ(filters[0].cd_values(), cdvalues);
+    EXPECT_EQ(filters[0].is_decoding_enabled(), true);
+    EXPECT_EQ(filters[0].is_encoding_enabled(), true);
+    EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_NBIT));
+    EXPECT_EQ(filters[0].name(), "nbit");
+  }
+}

--- a/test/filter/nbit_test.cpp
+++ b/test/filter/nbit_test.cpp
@@ -49,7 +49,7 @@ TEST(NBitTest,application)
     EXPECT_EQ(filter.id(), static_cast<int>(H5Z_FILTER_NBIT));
     EXPECT_EQ(filter.is_decoding_enabled(), true);
     EXPECT_EQ(filter.is_encoding_enabled(), true);
-    EXPECT_EQ(dcpl.nfilters(), 1lu);
+    EXPECT_EQ(dcpl.nfilters(), 1u);
     EXPECT_EQ(filters.size(), 1lu);
     EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
     EXPECT_EQ(filters.size(), 1lu);

--- a/test/filter/scaleoffset_test.cpp
+++ b/test/filter/scaleoffset_test.cpp
@@ -49,8 +49,8 @@ TEST(ScaleOffsetTest,application)
     EXPECT_EQ(scaleoffset.id(), static_cast<int>(H5Z_FILTER_SCALEOFFSET));
     EXPECT_EQ(scaleoffset.is_decoding_enabled(), true);
     EXPECT_EQ(scaleoffset.is_encoding_enabled(), true);
-    
-    EXPECT_EQ(dcpl.nfilters(), 1lu);
+
+    EXPECT_EQ(dcpl.nfilters(), 1u);
     EXPECT_EQ(filters.size(), 1lu);
     EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
     EXPECT_EQ(filters.size(), 1lu);
@@ -61,7 +61,7 @@ TEST(ScaleOffsetTest,application)
     EXPECT_EQ(filters[0].is_encoding_enabled(), true);
     EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_SCALEOFFSET));
     EXPECT_EQ(filters[0].name(), "scaleoffset");
-    
+
     EXPECT_EQ(scaleoffset.scale_type(), filter::SOScaleType::INT);
     EXPECT_EQ(scaleoffset.scale_factor(), 2);
     scaleoffset.scale_type(filter::SOScaleType::FLOAT_DSCALE);

--- a/test/filter/scaleoffset_test.cpp
+++ b/test/filter/scaleoffset_test.cpp
@@ -1,0 +1,74 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+#include <gtest/gtest.h>
+#include <h5cpp/hdf5.hpp>
+
+using namespace hdf5;
+
+TEST(ScaleOffsetTest,construction)
+{
+  filter::ScaleOffset filter;
+  EXPECT_EQ(filter.id(),H5Z_FILTER_SCALEOFFSET);
+}
+
+TEST(ScaleOffsetTest,application)
+{
+  filter::ScaleOffset scaleoffset(filter::SOScaleType::INT,2);
+  property::DatasetCreationList dcpl;
+
+  scaleoffset(dcpl);
+  filter::ExternalFilters filters;
+  auto flags = filters.fill(dcpl);
+  std::vector<unsigned int> cdvalues({2, 2});
+  if(filter::is_filter_available(H5Z_FILTER_SCALEOFFSET)){
+    // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+    EXPECT_EQ(scaleoffset.id(), static_cast<int>(H5Z_FILTER_SCALEOFFSET));
+    EXPECT_EQ(scaleoffset.is_decoding_enabled(), true);
+    EXPECT_EQ(scaleoffset.is_encoding_enabled(), true);
+    
+    EXPECT_EQ(dcpl.nfilters(), 1lu);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(flags.size(), 1lu);
+    EXPECT_EQ(flags[0], filter::Availability::OPTIONAL);
+    EXPECT_EQ(filters[0].cd_values(), cdvalues);
+    EXPECT_EQ(filters[0].is_decoding_enabled(), true);
+    EXPECT_EQ(filters[0].is_encoding_enabled(), true);
+    EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_SCALEOFFSET));
+    EXPECT_EQ(filters[0].name(), "scaleoffset");
+    
+    EXPECT_EQ(scaleoffset.scale_type(), filter::SOScaleType::INT);
+    EXPECT_EQ(scaleoffset.scale_factor(), 2);
+    scaleoffset.scale_type(filter::SOScaleType::FLOAT_DSCALE);
+    EXPECT_EQ(scaleoffset.scale_type(), filter::SOScaleType::FLOAT_DSCALE);
+    scaleoffset.scale_type(filter::SOScaleType::FLOAT_ESCALE);
+    EXPECT_EQ(scaleoffset.scale_type(), filter::SOScaleType::FLOAT_ESCALE);
+    scaleoffset.scale_factor(4);
+    EXPECT_EQ(scaleoffset.scale_factor(), 4);
+  }
+}

--- a/test/filter/szip_test.cpp
+++ b/test/filter/szip_test.cpp
@@ -1,0 +1,72 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5cpp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//         Eugen Wintersberger <eugen.wintersberger@desy.de>
+//         Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Dec 20, 2020
+//
+#include <gtest/gtest.h>
+#include <h5cpp/hdf5.hpp>
+
+using namespace hdf5;
+
+TEST(SZipTest,construction)
+{
+  filter::SZip filter;
+  EXPECT_EQ(filter.id(),H5Z_FILTER_SZIP);
+}
+
+TEST(SZipTest,application)
+{
+  filter::SZip szip(filter::SZip::EC_OPTION_MASK,16);
+  property::DatasetCreationList dcpl;
+
+  szip(dcpl);
+  filter::ExternalFilters filters;
+  auto flags = filters.fill(dcpl);
+  std::vector<unsigned int> cdvalues({133, 16});
+  if(filter::is_filter_available(H5Z_FILTER_SZIP)){
+    // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
+    EXPECT_EQ(szip.id(), static_cast<int>(H5Z_FILTER_SZIP));
+    EXPECT_EQ(szip.is_decoding_enabled(), true);
+    EXPECT_EQ(szip.is_encoding_enabled(), true);
+    
+    EXPECT_EQ(dcpl.nfilters(), 1lu);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
+    EXPECT_EQ(filters.size(), 1lu);
+    EXPECT_EQ(flags.size(), 1lu);
+    EXPECT_EQ(flags[0], filter::Availability::OPTIONAL);
+    EXPECT_EQ(filters[0].cd_values(), cdvalues);
+    EXPECT_EQ(filters[0].is_decoding_enabled(), true);
+    EXPECT_EQ(filters[0].is_encoding_enabled(), true);
+    EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_SZIP));
+    EXPECT_EQ(filters[0].name(), "szip");
+    
+    EXPECT_EQ(szip.options_mask(), filter::SZip::EC_OPTION_MASK);
+    EXPECT_EQ(szip.pixels_per_block(), 16);
+    szip.options_mask(filter::SZip::NN_OPTION_MASK);
+    EXPECT_EQ(szip.options_mask(), filter::SZip::NN_OPTION_MASK);
+    szip.pixels_per_block(32);
+    EXPECT_EQ(szip.pixels_per_block(), 32);
+  }
+}

--- a/test/filter/szip_test.cpp
+++ b/test/filter/szip_test.cpp
@@ -49,8 +49,8 @@ TEST(SZipTest,application)
     EXPECT_EQ(szip.id(), static_cast<int>(H5Z_FILTER_SZIP));
     EXPECT_EQ(szip.is_decoding_enabled(), true);
     EXPECT_EQ(szip.is_encoding_enabled(), true);
-    
-    EXPECT_EQ(dcpl.nfilters(), 1lu);
+
+    EXPECT_EQ(dcpl.nfilters(), 1u);
     EXPECT_EQ(filters.size(), 1lu);
     EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)),1);
     EXPECT_EQ(filters.size(), 1lu);
@@ -61,12 +61,12 @@ TEST(SZipTest,application)
     EXPECT_EQ(filters[0].is_encoding_enabled(), true);
     EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_SZIP));
     EXPECT_EQ(filters[0].name(), "szip");
-    
+
   }
   EXPECT_EQ(szip.options_mask(), filter::SZip::EC_OPTION_MASK);
-  EXPECT_EQ(szip.pixels_per_block(), 16);
+  EXPECT_EQ(szip.pixels_per_block(), 16u);
   szip.options_mask(filter::SZip::NN_OPTION_MASK);
   EXPECT_EQ(szip.options_mask(), filter::SZip::NN_OPTION_MASK);
   szip.pixels_per_block(32);
-  EXPECT_EQ(szip.pixels_per_block(), 32);
+  EXPECT_EQ(szip.pixels_per_block(), 32u);
 }

--- a/test/filter/szip_test.cpp
+++ b/test/filter/szip_test.cpp
@@ -40,11 +40,11 @@ TEST(SZipTest,application)
   filter::SZip szip(filter::SZip::EC_OPTION_MASK,16);
   property::DatasetCreationList dcpl;
 
-  szip(dcpl);
   filter::ExternalFilters filters;
-  auto flags = filters.fill(dcpl);
   std::vector<unsigned int> cdvalues({133, 16});
   if(filter::is_filter_available(H5Z_FILTER_SZIP)){
+    szip(dcpl);
+    auto flags = filters.fill(dcpl);
     // EXPECT_EQ(H5Pget_nfilters(static_cast<hid_t>(dcpl)), 1);
     EXPECT_EQ(szip.id(), static_cast<int>(H5Z_FILTER_SZIP));
     EXPECT_EQ(szip.is_decoding_enabled(), true);
@@ -62,11 +62,11 @@ TEST(SZipTest,application)
     EXPECT_EQ(filters[0].id(), static_cast<int>(H5Z_FILTER_SZIP));
     EXPECT_EQ(filters[0].name(), "szip");
     
-    EXPECT_EQ(szip.options_mask(), filter::SZip::EC_OPTION_MASK);
-    EXPECT_EQ(szip.pixels_per_block(), 16);
-    szip.options_mask(filter::SZip::NN_OPTION_MASK);
-    EXPECT_EQ(szip.options_mask(), filter::SZip::NN_OPTION_MASK);
-    szip.pixels_per_block(32);
-    EXPECT_EQ(szip.pixels_per_block(), 32);
   }
+  EXPECT_EQ(szip.options_mask(), filter::SZip::EC_OPTION_MASK);
+  EXPECT_EQ(szip.pixels_per_block(), 16);
+  szip.options_mask(filter::SZip::NN_OPTION_MASK);
+  EXPECT_EQ(szip.options_mask(), filter::SZip::NN_OPTION_MASK);
+  szip.pixels_per_block(32);
+  EXPECT_EQ(szip.pixels_per_block(), 32);
 }


### PR DESCRIPTION
It resolves #389 by adding `NBit`, `SZip` and `ScaleOffset` filters.

It also add `Filter:is_encoding_enabled()` and `Filter:is_decoding_enabled()` as well as `DatasetCreationList::nfilters()`
to provide more information about filters for the user.