### PR TITLE
Issue 478: fix typo of scale_factor in ScaleOffset declaration

### DIFF
--- a/src/h5cpp/filter/scaleoffset.hpp
+++ b/src/h5cpp/filter/scaleoffset.hpp
@@ -53,7 +53,7 @@ class DLL_EXPORT ScaleOffset : public Filter
     int scale_factor_;
   public:
     ScaleOffset();
-    ScaleOffset(SOScaleType scale_type, int scale_factor_);
+    ScaleOffset(SOScaleType scale_type, int scale_factor);
     ~ScaleOffset();
 
     SOScaleType scale_type() const noexcept;


### PR DESCRIPTION
It resolves #478 by changing `scale_factor_` to `scale_factor`