### PR TITLE
Optional docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,11 @@ include(${EXTRA_MODULES_DIR}/CompilerConfig.cmake)
 include(${EXTRA_MODULES_DIR}/MPIConfig.cmake)
 include(${EXTRA_MODULES_DIR}/HDF5LibraryConfig.cmake)
 
-add_custom_target(html)
 add_subdirectory(src)
-add_subdirectory(doc)
+set( BUILD_DOCS OFF CACHE BOOL "Build documentation")
+if(BUILD_DOCS)
+  add_subdirectory(doc)
+endif()
 
 #=============================================================================
 # install the examples directory to the documentation directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ include(${EXTRA_MODULES_DIR}/MPIConfig.cmake)
 include(${EXTRA_MODULES_DIR}/HDF5LibraryConfig.cmake)
 
 add_subdirectory(src)
-set( BUILD_DOCS OFF CACHE BOOL "Build documentation")
+set( BUILD_DOCS ON CACHE BOOL "Build documentation")
 if(BUILD_DOCS)
   add_subdirectory(doc)
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -16,6 +16,7 @@ add_custom_command(OUTPUT doxygen.stamp
                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doc)
 
 add_custom_target(api_doc DEPENDS doxygen.stamp)
+add_custom_target(html)
 add_dependencies(html api_doc)
 
 #=============================================================================


### PR DESCRIPTION
Hi I was using this library with CMake's FetchContent
```
FetchContent_Declare(
  h5cpp
  GIT_REPOSITORY https://github.com/ess-dmsc/h5cpp
  GIT_TAG origin/master)
FetchContent_MakeAvailable(h5cpp)
```
I found it useful to make the building of documentation optional, particularly because the `html` target conflicts with my own documentation target.