### PR TITLE
Use jenkins shared lib to setup Git user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,11 +187,10 @@ builders = pipeline_builder.createBuilders { container ->
 
       if (pipeline_builder.branch == 'master') {
         container.copyTo(pipeline_builder.project, "docs")
+        container.setupLocalGitUser("docs")
         container.sh """
           cd docs
 
-          git config user.email 'dm-jenkins-integration@esss.se'
-          git config user.name 'cow-bot'
           git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
 
           git fetch


### PR DESCRIPTION
This is a low priority change to move the user configuration for automated push to GitHub to the Jenkins shared library.