### PR TITLE
Issue 494: add checks for flags in from_buffer:  DONT_COPY without DONT_RELEASE

### DIFF
--- a/src/h5cpp/file/functions.hpp
+++ b/src/h5cpp/file/functions.hpp
@@ -131,15 +131,18 @@ File from_buffer(const T &data, ImageFlags flags)
 template<typename T>
 File from_buffer(const T &data, ImageFlagsBase flags)
 {
-  if((flags & static_cast<AccessFlagsBase>(ImageFlags::READWRITE))  &&
-     (flags & static_cast<AccessFlagsBase>(ImageFlags::DONT_COPY)))
-    throw std::runtime_error("Invalid ImageFlags for const buffer");
+  if((flags & static_cast<ImageFlagsBase>(ImageFlags::READWRITE))  &&
+     (flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_COPY)))
+    throw std::runtime_error("Invalid ImageFlags for const buffer: the DONT_COPY flag together with the READWRITE flag");
   return from_buffer(const_cast<T&>(data), static_cast<ImageFlagsBase>(flags));
 }
 
 template<typename T>
 File from_buffer(T &data, ImageFlagsBase flags)
 {
+  if ((flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_COPY)) &&
+      !(flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_RELEASE)))
+    throw std::runtime_error("Invalid ImageFlags in from_buffer: the DONT_COPY flag without the DONT_RELEASE flag");
   auto memory_space = hdf5::dataspace::create(data);
   auto memory_type  = hdf5::datatype::create(data);
   size_t databytesize = memory_space.size() * memory_type.size();

--- a/test/file/file_image_test.cpp
+++ b/test/file/file_image_test.cpp
@@ -172,11 +172,16 @@ TEST_F(FileImage, test_image_buffer_flags)
   EXPECT_EQ(realsize, size);
   nexus_file.close();
   const std::vector<unsigned char> cbuffer = buffer;
+  EXPECT_THROW(file::from_buffer(buffer, file::ImageFlags::DONT_COPY),
+	       std::runtime_error);
   EXPECT_THROW(file::from_buffer(cbuffer,
-				 file::ImageFlags::DONT_COPY | file::ImageFlags::READWRITE),
+				 file::ImageFlags::DONT_COPY |
+				 file::ImageFlags::DONT_RELEASE |
+				 file::ImageFlags::READWRITE),
 	       std::runtime_error);
   auto file2 = file::from_buffer(cbuffer,
-				 file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE); 
+				 file::ImageFlags::DONT_COPY |
+				 file::ImageFlags::DONT_RELEASE);
   auto r2 = file2.root();
 
   auto a = r2.attributes["HDF5_version"];


### PR DESCRIPTION
It resolves #494 by adding checks  for flags in `from_buffer(data, flags)`:  `DONT_COPY` without `DONT_RELEASE`