### PR TITLE
Issue 497: add and operators for ImageFlags, SearchFlags, AccessFlags and CopyFlags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,7 +179,7 @@ builders = pipeline_builder.createBuilders { container ->
   if (container.key == documentation_os) {
     pipeline_builder.stage("Documentation") {
       container.sh """
-        pip3 --proxy=${http_proxy} install --user sphinx breathe
+        pip3 --proxy=${http_proxy} install --user sphinx==4.0.3 breathe
         export PATH=$PATH:~/.local/bin
         cd build
         make html

--- a/src/h5cpp/file/functions.hpp
+++ b/src/h5cpp/file/functions.hpp
@@ -131,8 +131,7 @@ File from_buffer(const T &data, ImageFlags flags)
 template<typename T>
 File from_buffer(const T &data, ImageFlagsBase flags)
 {
-  if((flags & static_cast<ImageFlagsBase>(ImageFlags::READWRITE))  &&
-     (flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_COPY)))
+  if((flags & ImageFlags::READWRITE) && (flags & ImageFlags::DONT_COPY))
     throw std::runtime_error("Invalid ImageFlags for const buffer: the DONT_COPY flag together with the READWRITE flag");
   return from_buffer(const_cast<T&>(data), static_cast<ImageFlagsBase>(flags));
 }
@@ -140,8 +139,7 @@ File from_buffer(const T &data, ImageFlagsBase flags)
 template<typename T>
 File from_buffer(T &data, ImageFlagsBase flags)
 {
-  if ((flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_COPY)) &&
-      !(flags & static_cast<ImageFlagsBase>(ImageFlags::DONT_RELEASE)))
+  if ((flags & ImageFlags::DONT_COPY) && !(flags & ImageFlags::DONT_RELEASE))
     throw std::runtime_error("Invalid ImageFlags in from_buffer: the DONT_COPY flag without the DONT_RELEASE flag");
   auto memory_space = hdf5::dataspace::create(data);
   auto memory_type  = hdf5::datatype::create(data);

--- a/src/h5cpp/file/types.cpp
+++ b/src/h5cpp/file/types.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Sep 8, 2017
 //
 
@@ -61,6 +63,21 @@ AccessFlagsBase operator|(const AccessFlags &lhs,const AccessFlagsBase &rhs)
   return static_cast<AccessFlagsBase>(lhs) | rhs;
 }
 
+AccessFlagsBase operator&(const AccessFlags &lhs,const AccessFlags &rhs)
+{
+  return static_cast<AccessFlagsBase>(lhs) & static_cast<AccessFlagsBase>(rhs);
+}
+
+AccessFlagsBase operator&(const AccessFlagsBase &lhs,const AccessFlags &rhs)
+{
+  return lhs & static_cast<AccessFlagsBase>(rhs);
+}
+
+AccessFlagsBase operator&(const AccessFlags &lhs,const AccessFlagsBase &rhs)
+{
+  return static_cast<AccessFlagsBase>(lhs) & rhs;
+}
+
 std::ostream &operator<<(std::ostream &stream,const ImageFlags &flags)
 {
   switch(flags)
@@ -91,6 +108,21 @@ ImageFlagsBase operator|(const ImageFlags &lhs,const ImageFlagsBase &rhs)
   return static_cast<ImageFlagsBase>(lhs) | rhs;
 }
 
+ImageFlagsBase operator&(const ImageFlags &lhs,const ImageFlags &rhs)
+{
+  return static_cast<ImageFlagsBase>(lhs) & static_cast<ImageFlagsBase>(rhs);
+}
+
+ImageFlagsBase operator&(const ImageFlagsBase &lhs,const ImageFlags &rhs)
+{
+  return lhs & static_cast<ImageFlagsBase>(rhs);
+}
+
+ImageFlagsBase operator&(const ImageFlags &lhs,const ImageFlagsBase &rhs)
+{
+  return static_cast<ImageFlagsBase>(lhs) & rhs;
+}
+
 std::ostream &operator<<(std::ostream &stream,const SearchFlags &flags)
 {
   switch(flags)
@@ -119,7 +151,22 @@ SearchFlagsBase operator|(const SearchFlags &lhs,const SearchFlagsBase &rhs)
 
 SearchFlagsBase operator|(const SearchFlagsBase &lhs,const SearchFlags &rhs)
 {
-  return rhs | lhs;
+  return rhs | static_cast<SearchFlagsBase>(lhs);
+}
+
+ SearchFlagsBase operator&(const SearchFlags &lhs,const SearchFlags &rhs)
+{
+  return static_cast<SearchFlagsBase>(lhs) & static_cast<SearchFlagsBase>(rhs);
+}
+
+SearchFlagsBase operator&(const SearchFlags &lhs,const SearchFlagsBase &rhs)
+{
+  return static_cast<SearchFlagsBase>(lhs) & rhs;
+}
+
+SearchFlagsBase operator&(const SearchFlagsBase &lhs,const SearchFlags &rhs)
+{
+  return rhs & static_cast<SearchFlagsBase>(lhs);
 }
 
 std::ostream &operator<<(std::ostream &stream,const Scope &scope)

--- a/src/h5cpp/file/types.hpp
+++ b/src/h5cpp/file/types.hpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Sep 8, 2017
 //
 #pragma once
@@ -53,6 +55,10 @@ DLL_EXPORT AccessFlagsBase operator|(const AccessFlags &lhs,const AccessFlags &r
 DLL_EXPORT AccessFlagsBase operator|(const AccessFlagsBase &lhs,const AccessFlags &rhs);
 DLL_EXPORT AccessFlagsBase operator|(const AccessFlags &lhs,const AccessFlagsBase &rhs);
 
+DLL_EXPORT AccessFlagsBase operator&(const AccessFlags &lhs,const AccessFlags &rhs);
+DLL_EXPORT AccessFlagsBase operator&(const AccessFlagsBase &lhs,const AccessFlags &rhs);
+DLL_EXPORT AccessFlagsBase operator&(const AccessFlags &lhs,const AccessFlagsBase &rhs);
+
 //!
 //! \brief flags controlling image file opening and getting
 //!
@@ -72,6 +78,10 @@ DLL_EXPORT std::ostream &operator<<(std::ostream &stream,const ImageFlags &flags
 DLL_EXPORT ImageFlagsBase operator|(const ImageFlags &lhs,const ImageFlags &rhs);
 DLL_EXPORT ImageFlagsBase operator|(const ImageFlagsBase &lhs,const ImageFlags &rhs);
 DLL_EXPORT ImageFlagsBase operator|(const ImageFlags &lhs,const ImageFlagsBase &rhs);
+
+DLL_EXPORT ImageFlagsBase operator&(const ImageFlags &lhs,const ImageFlags &rhs);
+DLL_EXPORT ImageFlagsBase operator&(const ImageFlagsBase &lhs,const ImageFlags &rhs);
+DLL_EXPORT ImageFlagsBase operator&(const ImageFlags &lhs,const ImageFlagsBase &rhs);
 
 //!
 //! \brief flags controlling object search in a file
@@ -94,6 +104,10 @@ DLL_EXPORT std::ostream &operator<<(std::ostream &stream,const SearchFlags &flag
 DLL_EXPORT SearchFlagsBase operator|(const SearchFlags &lhs,const SearchFlags &rhs);
 DLL_EXPORT SearchFlagsBase operator|(const SearchFlags &lhs,const SearchFlagsBase &rhs);
 DLL_EXPORT SearchFlagsBase operator|(const SearchFlagsBase &lhs,const SearchFlags &rhs);
+
+DLL_EXPORT SearchFlagsBase operator&(const SearchFlags &lhs,const SearchFlags &rhs);
+DLL_EXPORT SearchFlagsBase operator&(const SearchFlags &lhs,const SearchFlagsBase &rhs);
+DLL_EXPORT SearchFlagsBase operator&(const SearchFlagsBase &lhs,const SearchFlags &rhs);
 
 //!
 //! \brief file scope

--- a/src/h5cpp/property/object_copy.cpp
+++ b/src/h5cpp/property/object_copy.cpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Oct 09, 2017
 //
 
@@ -46,6 +47,10 @@ std::ostream &operator<<(std::ostream &stream, const CopyFlag &flag) {
 
 CopyFlags operator|(const CopyFlag &lhs, const CopyFlag &rhs) {
   return CopyFlags(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
+}
+
+CopyFlags operator&(const CopyFlag &lhs, const CopyFlag &rhs) {
+  return CopyFlags(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
 }
 
 CopyFlags::CopyFlags() noexcept:
@@ -73,6 +78,28 @@ CopyFlags &CopyFlags::operator|=(const CopyFlag &flag) noexcept {
 
 CopyFlags &CopyFlags::operator|=(const CopyFlags &flags) noexcept {
   value_ |= static_cast<unsigned>(flags);
+  return *this;
+}
+
+CopyFlags operator&(const CopyFlags &flags, const CopyFlags &rhs) noexcept {
+  return CopyFlags(static_cast<unsigned>(flags) & static_cast<unsigned>(rhs));
+}
+
+CopyFlags operator&(const CopyFlags &flags, const CopyFlag &flag) noexcept {
+  return CopyFlags(static_cast<unsigned>(flags) & static_cast<unsigned>(flag));
+}
+
+CopyFlags operator&(const CopyFlag &flag, const CopyFlags &flags) noexcept {
+  return CopyFlags(static_cast<unsigned>(flag) & static_cast<unsigned>(flags));
+}
+
+CopyFlags &CopyFlags::operator&=(const CopyFlag &flag) noexcept {
+  value_ &= static_cast<unsigned>(flag);
+  return *this;
+}
+
+CopyFlags &CopyFlags::operator&=(const CopyFlags &flags) noexcept {
+  value_ &= static_cast<unsigned>(flags);
   return *this;
 }
 

--- a/src/h5cpp/property/object_copy.hpp
+++ b/src/h5cpp/property/object_copy.hpp
@@ -22,6 +22,7 @@
 // Authors:
 //   Eugen Wintersberger <eugen.wintersberger@desy.de>
 //   Martin Shetty <martin.shetty@esss.se>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Oct 09, 2017
 //
 #pragma once
@@ -45,6 +46,8 @@ enum class CopyFlag : unsigned {
 DLL_EXPORT std::ostream &operator<<(std::ostream &stream, const CopyFlag &flag);
 
 DLL_EXPORT CopyFlags operator|(const CopyFlag &lhs, const CopyFlag &rhs);
+
+DLL_EXPORT CopyFlags operator&(const CopyFlag &lhs, const CopyFlag &rhs);
 
 //!
 //! \brief encapsulate copy flags
@@ -87,6 +90,16 @@ class DLL_EXPORT CopyFlags {
   //! \brief unary logical or operator
   //!
   CopyFlags &operator|=(const CopyFlags &flags) noexcept;
+
+  //!
+  //! \brief unary logical and operator
+  //!
+  CopyFlags &operator&=(const CopyFlag &flag) noexcept;
+
+  //!
+  //! \brief unary logical and operator
+  //!
+  CopyFlags &operator&=(const CopyFlags &flags) noexcept;
 
   //!
   //! \brief allow for explicit conversion to unsigned
@@ -171,6 +184,21 @@ DLL_EXPORT CopyFlags operator|(const CopyFlags &flags, const CopyFlag &flag) noe
 //! \brief binary or operator for copy flags
 //!
 DLL_EXPORT CopyFlags operator|(const CopyFlag &flag, const CopyFlags &flags) noexcept;
+
+//!
+//! \brief binary or operator for copy flags
+//!
+DLL_EXPORT CopyFlags operator&(const CopyFlags &flags, const CopyFlags &rhs) noexcept;
+
+//!
+//! \brief binary or operator for copy flags
+//!
+DLL_EXPORT CopyFlags operator&(const CopyFlags &flags, const CopyFlag &flag) noexcept;
+
+//!
+//! \brief binary or operator for copy flags
+//!
+DLL_EXPORT CopyFlags operator&(const CopyFlag &flag, const CopyFlags &flags) noexcept;
 
 class DLL_EXPORT ObjectCopyList : public List {
  public:

--- a/src/h5cpp/property/object_copy.hpp
+++ b/src/h5cpp/property/object_copy.hpp
@@ -186,17 +186,17 @@ DLL_EXPORT CopyFlags operator|(const CopyFlags &flags, const CopyFlag &flag) noe
 DLL_EXPORT CopyFlags operator|(const CopyFlag &flag, const CopyFlags &flags) noexcept;
 
 //!
-//! \brief binary or operator for copy flags
+//! \brief binary and operator for copy flags
 //!
 DLL_EXPORT CopyFlags operator&(const CopyFlags &flags, const CopyFlags &rhs) noexcept;
 
 //!
-//! \brief binary or operator for copy flags
+//! \brief binary and operator for copy flags
 //!
 DLL_EXPORT CopyFlags operator&(const CopyFlags &flags, const CopyFlag &flag) noexcept;
 
 //!
-//! \brief binary or operator for copy flags
+//! \brief binary and operator for copy flags
 //!
 DLL_EXPORT CopyFlags operator&(const CopyFlag &flag, const CopyFlags &flags) noexcept;
 

--- a/test/file/CMakeLists.txt
+++ b/test/file/CMakeLists.txt
@@ -4,6 +4,7 @@ set(test_sources
   ${test_sources}
   ${dir}/searchflags_test.cpp
   ${dir}/accessflags_test.cpp
+  ${dir}/imageflags_test.cpp
   ${dir}/scope_test.cpp
   ${dir}/file_test.cpp
   ${dir}/file_creation_test.cpp

--- a/test/file/accessflags_test.cpp
+++ b/test/file/accessflags_test.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Sep 8, 2017
 //
 
@@ -56,6 +58,34 @@ TEST(AccessFlags, test_output_stream)
   stream<<file::AccessFlags::SWMR_READ;
   EXPECT_EQ(stream.str(), "SWMR READ");
 #endif
+}
+
+TEST(AccessFlags, test_or_flags) {
+  EXPECT_EQ(file::AccessFlags::READWRITE | file::AccessFlags::TRUNCATE,
+            H5F_ACC_RDWR | H5F_ACC_TRUNC);
+
+  EXPECT_EQ(file::AccessFlags::EXCLUSIVE | file::AccessFlags::READONLY,
+            H5F_ACC_EXCL | H5F_ACC_RDONLY);
+}
+
+TEST(AccessFlags, test_or_left_three)
+{
+  EXPECT_EQ(file::AccessFlags::READWRITE | file::AccessFlags::TRUNCATE |
+            file::AccessFlags::EXCLUSIVE,
+            H5F_ACC_RDWR | H5F_ACC_TRUNC | H5F_ACC_EXCL);
+}
+
+TEST(AccessFlags, test_and_or_comb)
+{
+  EXPECT_EQ((file::AccessFlags::READWRITE | file::AccessFlags::TRUNCATE) &
+            file::AccessFlags::READWRITE,
+            H5F_ACC_RDWR);
+  EXPECT_EQ(file::AccessFlags::TRUNCATE &
+	    (file::AccessFlags::READWRITE | file::AccessFlags::TRUNCATE),
+            H5F_ACC_TRUNC);
+  EXPECT_EQ((file::AccessFlags::READWRITE | file::AccessFlags::TRUNCATE) &
+	    (file::AccessFlags::READWRITE | file::AccessFlags::EXCLUSIVE),
+            H5F_ACC_RDWR);
 }
 
 TEST(AccessFlags, test_values)

--- a/test/file/imageflags_test.cpp
+++ b/test/file/imageflags_test.cpp
@@ -1,0 +1,106 @@
+//
+// (c) Copyright 2017 DESY,ESS
+//
+// This file is part of h5pp.
+//
+// This library is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation; either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty ofMERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+// License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this library; if not, write to the
+// Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+// Boston, MA  02110-1301 USA
+// ===========================================================================
+//
+// Authors:
+//   Jan Kotanski <jan.kotanski@desy.de>
+// Created on: Sep 8, 2021
+//
+
+#include <gtest/gtest.h>
+#include <h5cpp/file/types.hpp>
+
+using namespace hdf5;
+
+TEST(ImageFlags, test_output_stream)
+{
+  std::stringstream stream;
+
+  stream.str(std::string());
+  stream<<file::ImageFlags::READONLY;
+  EXPECT_EQ(stream.str(), "READONLY");
+
+  stream.str(std::string());
+  stream<<file::ImageFlags::DONT_COPY;
+  EXPECT_EQ(stream.str(), "DONT COPY");
+
+  stream.str(std::string());
+  stream<<file::ImageFlags::READWRITE;
+  EXPECT_EQ(stream.str(), "READWRITE");
+
+  stream.str(std::string());
+  stream<<file::ImageFlags::DONT_RELEASE;
+  EXPECT_EQ(stream.str(), "DONT RELEASE");
+  
+  stream.str(std::string());
+  stream<<file::ImageFlags::ALL;
+  EXPECT_EQ(stream.str(), "ALL");
+
+}
+
+TEST(ImageFlags, test_or_flags) {
+  EXPECT_EQ(file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE,
+            H5LT_FILE_IMAGE_DONT_COPY | H5LT_FILE_IMAGE_DONT_RELEASE);
+
+  EXPECT_EQ(file::ImageFlags::READONLY | file::ImageFlags::READWRITE,
+            H5LT_FILE_IMAGE_OPEN_RW);
+  EXPECT_EQ(file::ImageFlags::ALL | file::ImageFlags::READWRITE,
+	    H5LT_FILE_IMAGE_ALL);
+}
+
+TEST(ImageFlags, test_or_left_three)
+{
+  EXPECT_EQ(file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE |
+            file::ImageFlags::READWRITE,
+            H5LT_FILE_IMAGE_DONT_COPY | H5LT_FILE_IMAGE_DONT_RELEASE |
+            H5LT_FILE_IMAGE_OPEN_RW);
+  EXPECT_EQ(file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE |
+            file::ImageFlags::READWRITE,
+            H5LT_FILE_IMAGE_ALL);
+}
+
+TEST(ImageFlags, test_and_or_comb)
+{
+  EXPECT_EQ((file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE) &
+            file::ImageFlags::DONT_COPY,
+            H5LT_FILE_IMAGE_DONT_COPY);
+  EXPECT_EQ(file::ImageFlags::DONT_RELEASE &
+	    (file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE),
+            H5LT_FILE_IMAGE_DONT_RELEASE);
+  EXPECT_EQ((file::ImageFlags::DONT_COPY | file::ImageFlags::DONT_RELEASE) &
+	    (file::ImageFlags::DONT_COPY | file::ImageFlags::READWRITE),
+            H5LT_FILE_IMAGE_DONT_COPY);
+}
+
+TEST(ImageFlags, test_values)
+{
+  EXPECT_EQ(static_cast<file::ImageFlagsBase>(file::ImageFlags::READONLY),
+                    0x0000);
+  EXPECT_EQ(static_cast<file::ImageFlagsBase>(file::ImageFlags::READWRITE),
+                    H5LT_FILE_IMAGE_OPEN_RW);
+  EXPECT_EQ(static_cast<file::ImageFlagsBase>(file::ImageFlags::DONT_COPY),
+                    H5LT_FILE_IMAGE_DONT_COPY);
+  EXPECT_EQ(static_cast<file::ImageFlagsBase>(file::ImageFlags::DONT_RELEASE),
+                    H5LT_FILE_IMAGE_DONT_RELEASE);
+  EXPECT_EQ(static_cast<file::ImageFlagsBase>(file::ImageFlags::ALL),
+                    H5LT_FILE_IMAGE_ALL);
+}
+
+

--- a/test/file/searchflags_test.cpp
+++ b/test/file/searchflags_test.cpp
@@ -19,7 +19,9 @@
 // Boston, MA  02110-1301 USA
 // ===========================================================================
 //
-// Author: Eugen Wintersberger <eugen.wintersberger@desy.de>
+// Authors:
+//   Eugen Wintersberger <eugen.wintersberger@desy.de>
+//   Jan Kotanski <jan.kotanski@desy.de>
 // Created on: Sep 8, 2017
 //
 
@@ -75,6 +77,19 @@ TEST(SearchFlags, test_or_left_three)
   EXPECT_EQ(file::SearchFlags::ATTRIBUTE | file::SearchFlags::DATASET |
             file::SearchFlags::DATATYPE,
             H5F_OBJ_ATTR | H5F_OBJ_DATASET | H5F_OBJ_DATATYPE);
+}
+
+TEST(SearchFlags, test_and_or_comb)
+{
+  EXPECT_EQ((file::SearchFlags::DATATYPE | file::SearchFlags::DATASET) &
+            file::SearchFlags::DATATYPE,
+            H5F_OBJ_DATATYPE);
+  EXPECT_EQ(file::SearchFlags::ATTRIBUTE &
+	    (file::SearchFlags::ATTRIBUTE | file::SearchFlags::DATASET),
+            H5F_OBJ_ATTR);
+  EXPECT_EQ((file::SearchFlags::DATATYPE | file::SearchFlags::DATASET) &
+	    (file::SearchFlags::ATTRIBUTE | file::SearchFlags::DATASET),
+            H5F_OBJ_DATASET);
 }
 
 TEST(SearchFlags, test_values)

--- a/test/property/object_copy_test.cpp
+++ b/test/property/object_copy_test.cpp
@@ -207,6 +207,31 @@ TEST(CopyFlags, test_or_operations_1) {
   EXPECT_TRUE(flags.expand_external_links());
 }
 
+TEST(CopyFlags, test_and_or_comb)
+{
+  property::CopyFlags flags1 =
+    (property::CopyFlag::EXPAND_EXTERNAL_LINKS |
+     property::CopyFlag::EXPAND_SOFT_LINKS) &
+    property::CopyFlag::EXPAND_EXTERNAL_LINKS;
+  EXPECT_TRUE(!flags1.expand_soft_links());
+  EXPECT_TRUE(flags1.expand_external_links());
+
+  property::CopyFlags flags2 =
+    property::CopyFlag::EXPAND_EXTERNAL_LINKS &
+    (property::CopyFlag::EXPAND_EXTERNAL_LINKS |
+     property::CopyFlag::EXPAND_SOFT_LINKS);
+  EXPECT_TRUE(!flags2.expand_soft_links());
+  EXPECT_TRUE(flags2.expand_external_links());
+
+  property::CopyFlags flags3 =
+    (property::CopyFlag::EXPAND_EXTERNAL_LINKS |
+     property::CopyFlag::EXPAND_SOFT_LINKS) &
+    (property::CopyFlag::WITHOUT_ATTRIBUTES |
+     property::CopyFlag::EXPAND_SOFT_LINKS);
+  EXPECT_TRUE(flags3.expand_soft_links());
+  EXPECT_TRUE(!flags3.expand_external_links());
+}
+
 TEST(ObjectCopy, construction) {
   property::ObjectCopyList ocpl;
   EXPECT_TRUE(ocpl.get_class() == property::kObjectCopy);


### PR DESCRIPTION
It resolves #497 by adding `&` operators for ImageFlags, SearchFlags, AccessFlags and CopyFlags.
Moreover, it fixes a typo in `operator|` of SearchFlags.