### PR TITLE
Issue 503b: change Twos_Complement to TwosComplement

### DIFF
--- a/doc/design/model.uml
+++ b/doc/design/model.uml
@@ -249,7 +249,7 @@ Just provide a specizlization of this trait for your type (class).</body>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_A1EZoJPAEeeoI7oI9Ds2zg" name="BE"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_SEPQ0JO_EeeoI7oI9Ds2zg" name="Sign">
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8xR0EJO_EeeoI7oI9Ds2zg" name="Twos_Complement"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_8xR0EJO_EeeoI7oI9Ds2zg" name="TwosComplement"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_9hODQJO_EeeoI7oI9Ds2zg" name="Unsigned"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_UUli0JO_EeeoI7oI9Ds2zg" name="Norm">

--- a/doc/source/users_guide/dataspace.rst
+++ b/doc/source/users_guide/dataspace.rst
@@ -47,11 +47,11 @@ the dataspace there is currently
 
 .. cpp:enum-class:: Type
 
-    .. cpp:enumerator:: SIMPLE 
+    .. cpp:enumerator:: Simple
     
         for a simple datatype
         
-    .. cpp:enumerator:: SCALAR
+    .. cpp:enumerator:: Scalar
     
         for a scalar datatype
 

--- a/src/h5cpp/datatype/types.cpp
+++ b/src/h5cpp/datatype/types.cpp
@@ -58,7 +58,7 @@ std::ostream &operator<<(std::ostream &stream, const Order &o) {
 
 std::ostream &operator<<(std::ostream &stream, const Sign &s) {
   switch (s) {
-    case Sign::Twos_Complement: return stream << "TWOS COMPLEMENT";
+    case Sign::TwosComplement: return stream << "TWOS COMPLEMENT";
     case Sign::Unsigned: return stream << "UNSIGNED";
     default:return stream;
   }

--- a/src/h5cpp/datatype/types.hpp
+++ b/src/h5cpp/datatype/types.hpp
@@ -99,7 +99,7 @@ DLL_EXPORT std::ostream &operator<<(std::ostream &stream, const Order &o);
 //!
 enum class Sign : std::underlying_type<H5T_sign_t>::type
 {
-  Twos_Complement = H5T_SGN_2, //!< indicates a signed type
+  TwosComplement = H5T_SGN_2, //!< indicates a signed type
   Unsigned = H5T_SGN_NONE      //!< indicates an unsigned type
 };
 

--- a/test/datatype/type_test.cpp
+++ b/test/datatype/type_test.cpp
@@ -76,7 +76,7 @@ SCENARIO("Enumeration stream IO") {
   GIVEN("write the sign enumeration") {
     using ptype = std::tuple<Sign, std::string>;
     auto param = GENERATE(table<Sign, std::string>(
-        {ptype{Sign::Twos_Complement, "TWOS COMPLEMENT"},
+        {ptype{Sign::TwosComplement, "TWOS COMPLEMENT"},
          ptype{Sign::Unsigned, "UNSIGNED"}}));
     WHEN("writing the sign to the stream") {
       stream << value(param);


### PR DESCRIPTION
In PR #521 I forgot to change Twos_Complement to TwosComplement (Correction to #503). 