### PR TITLE
Issue 507: remove current_dimensions for Dataspace

### DIFF
--- a/src/h5cpp/dataspace/dataspace.cpp
+++ b/src/h5cpp/dataspace/dataspace.cpp
@@ -94,11 +94,6 @@ Type Dataspace::type() const {
 
 }
 
-hdf5::Dimensions Dataspace::current_dimensions() const
-{
-  return Dimensions();
-}
-
 bool Dataspace::is_valid() const {
   return handle_.is_valid();
 }

--- a/src/h5cpp/dataspace/dataspace.hpp
+++ b/src/h5cpp/dataspace/dataspace.hpp
@@ -93,13 +93,6 @@ class DLL_EXPORT Dataspace {
   virtual hssize_t size() const;
 
   //!
-  //! \brief current dimensions of a dataspace
-  //!
-  //! Return the current dimensions of a dataspace.
-  //!
-  hdf5::Dimensions current_dimensions() const;
-
-  //!
   //! \brief allows explicit conversion to hid_t
   //!
   //! This function is mainly used by \c static_cast for explicit

--- a/test/dataspace/scalar_test.cpp
+++ b/test/dataspace/scalar_test.cpp
@@ -45,9 +45,6 @@ SCENARIO("default construction of a scalar dataspace") {
     Scalar space;
     THEN("the size is 1") { REQUIRE(space.size() == 1); }
     THEN("type must be scalar") { REQUIRE(space.type() == Type::Scalar); }
-    THEN("the dimensions must be empty") {
-      REQUIRE(space.current_dimensions().empty());
-    }
   }
 }
 
@@ -58,9 +55,6 @@ SCENARIO("construction from a hid_t") {
       Scalar space{ObjectHandle(id)};
       AND_THEN("the size is 1") { REQUIRE(space.size() == 1); }
       AND_THEN("type must be scalar") { REQUIRE(space.type() == Type::Scalar); }
-      AND_THEN("the dimensions must be empty") {
-        REQUIRE(space.current_dimensions().empty());
-      }
     }
   }
 


### PR DESCRIPTION
It resolves #507 by removing  `current_dimensions()` method for `Dataspace`. In order to get current dimensions one needs to use `Simple.current_dimensions()`