### PR TITLE
Issue 528: change all-caps names to lower case names

### DIFF
--- a/doc/source/advanced/cpp_datastructures.rst
+++ b/doc/source/advanced/cpp_datastructures.rst
@@ -48,21 +48,21 @@ compliant with a memor storage. Cnsider the following example
     using MCAReadout = std::vector<BinType>;
     using MCAStack = std::vector<MCAReadout>;
 
-    #define NBINS 1024
-    #define NMCAS 100
+    static const int nbins = 1024;
+    static const int nmcas = 100;
 
     using namespace hdf5;
 
     // create the dataset
     node::Gruop data_group = ....;
     auto file_type = datatype::create<BinType>;
-    dataspace::Simple file_space({NMCAS,NBINS})
+    dataspace::Simple file_space({nmcas,nbins})
     node::Dataset dset = data_gruop.create_dataset("mcas",file_type,file_space);
 
     // create the data
     MCAStack mcas;
     MCAReader reader;
-    std::generate_n(std::back_inserter(mcas),NMCAS,reader);
+    std::generate_n(std::back_inserter(mcas),nmcas,reader);
 
 
     //now lets try to write the data

--- a/doc/source/users_guide/dataspace.rst
+++ b/doc/source/users_guide/dataspace.rst
@@ -133,7 +133,7 @@ along a dimension we could use
 
     using namespace hdf5;
     
-    dataspace::Simple space({1},{dataspace::Simple::UNLIMITED}); 
+    dataspace::Simple space({1},{dataspace::Simple::unlimited}); 
     
 .. figure:: ../images/dynamic_dataspace_unbounded.svg
    :align: center

--- a/examples/append_scalar_data.cpp
+++ b/examples/append_scalar_data.cpp
@@ -37,7 +37,7 @@ node::Dataset create_dataset(const node::Group parent_group)
   dcpl.chunk(Dimensions{1024});
 
   // create dataspace (infinitely extensible) and datatype
-  dataspace::Simple space({0},{dataspace::Simple::UNLIMITED});
+  dataspace::Simple space({0},{dataspace::Simple::unlimited});
   auto type = datatype::create<int>();
 
   // finally create the dataset

--- a/examples/append_vector_data.cpp
+++ b/examples/append_vector_data.cpp
@@ -30,7 +30,7 @@
 using namespace hdf5;
 
 using Bins = std::vector<int>;
-#define NBINS 6
+static const int nbins = 6;
 
 node::Dataset create_dataset(const node::Group parent_group,const Bins bins)
 {
@@ -39,7 +39,7 @@ node::Dataset create_dataset(const node::Group parent_group,const Bins bins)
   dcpl.layout(property::DatasetLayout::Chunked);
   dcpl.chunk({100,bins.size()});
 
-  dataspace::Simple space{{0,bins.size()},{dataspace::Simple::UNLIMITED,NBINS}};
+  dataspace::Simple space{{0,bins.size()},{dataspace::Simple::unlimited,nbins}};
   auto type = datatype::create(bins);
 
   return node::Dataset(parent_group,"data",type,space,lcpl,dcpl);
@@ -58,7 +58,7 @@ int main()
   file::File f = file::create("append_vector_data.h5",
                               file::AccessFlags::Truncate);
   node::Group root_group = f.root();
-  Bins data(NBINS);
+  Bins data(nbins);
   node::Dataset dataset = create_dataset(root_group,data);
 
   //

--- a/examples/mpi/writer_extend.cpp
+++ b/examples/mpi/writer_extend.cpp
@@ -43,7 +43,7 @@ file::File create_file(MPI_Comm comm,MPI_Info info)
 node::Dataset create_dataset(const node::Group &base)
 {
   auto file_type = datatype::create<int>();
-  dataspace::Simple file_space{{0},{dataspace::Simple::UNLIMITED}};
+  dataspace::Simple file_space{{0},{dataspace::Simple::unlimited}};
 
   property::LinkCreationList lcpl;
   property::DatasetCreationList dcpl;

--- a/examples/read_dataset.cpp
+++ b/examples/read_dataset.cpp
@@ -34,7 +34,7 @@ void createFile() {
 
   std::vector<int> Data{1, 2, 3, 4, 5, 6};
   Dimensions Shape{2, 3};
-  Dimensions MaxShape{dataspace::Simple::UNLIMITED, 3};
+  Dimensions MaxShape{dataspace::Simple::unlimited, 3};
   Dimensions ChunkSize{512, 3};
   dataspace::Simple Dataspace{Shape, MaxShape};
   datatype::Datatype Datatype = datatype::create<std::int32_t>();

--- a/examples/swmr/swmr_builder.cpp
+++ b/examples/swmr/swmr_builder.cpp
@@ -36,7 +36,7 @@ void SWMRBuilder::operator()(const node::Group &parent) const
   dcpl.chunk({1024*1024});
 
   auto type = datatype::create<double>();
-  dataspace::Simple space({0},{dataspace::Simple::UNLIMITED});
+  dataspace::Simple space({0},{dataspace::Simple::unlimited});
 
   node::Dataset(parent,"data",type,space,lcpl,dcpl);
 

--- a/examples/write_vector_list.cpp
+++ b/examples/write_vector_list.cpp
@@ -68,7 +68,7 @@ node::Dataset create_vector_dataset(const std::string &name,const node::Group &p
   dcpl.chunk(Dimensions{1024});
 
   auto datatype = datatype::TypeTrait<DoubleVector>::create();
-  dataspace::Simple dataspace({0},{dataspace::Simple::UNLIMITED});
+  dataspace::Simple dataspace({0},{dataspace::Simple::unlimited});
 
   return node::Dataset(parent_group,name,datatype,dataspace,lcpl,dcpl);
 }

--- a/src/h5cpp/dataspace/simple.cpp
+++ b/src/h5cpp/dataspace/simple.cpp
@@ -30,7 +30,7 @@
 namespace hdf5 {
 namespace dataspace {
   
-const hsize_t Simple::UNLIMITED = H5S_UNLIMITED;
+const hsize_t Simple::unlimited = H5S_UNLIMITED;
 
 Simple::Simple() :
     Dataspace(Type::Simple) {}

--- a/src/h5cpp/dataspace/simple.hpp
+++ b/src/h5cpp/dataspace/simple.hpp
@@ -45,7 +45,7 @@ class DLL_EXPORT Simple : public Dataspace {
   //!
   //! \brief dimension value for unlimited number of elements
   //!
-  static const hsize_t UNLIMITED;
+  static const hsize_t unlimited;
 
   //!
   //! \brief default constructor

--- a/src/h5cpp/filter/szip.cpp
+++ b/src/h5cpp/filter/szip.cpp
@@ -77,8 +77,8 @@ void SZip::operator()(const property::DatasetCreationList &dcpl,
   }
 }
 
-const unsigned int SZip::EC_OPTION_MASK = H5_SZIP_EC_OPTION_MASK;
-const unsigned int SZip::NN_OPTION_MASK = H5_SZIP_NN_OPTION_MASK;
+const unsigned int SZip::ec_option_mask = H5_SZIP_EC_OPTION_MASK;
+const unsigned int SZip::nn_option_mask = H5_SZIP_NN_OPTION_MASK;
 
 
 } // namespace filter

--- a/src/h5cpp/filter/szip.hpp
+++ b/src/h5cpp/filter/szip.hpp
@@ -57,9 +57,9 @@ class DLL_EXPORT SZip : public Filter
                             Availability flag=Availability::Mandatory) const override;
 
     // Selects entropy coding method
-    static const unsigned int EC_OPTION_MASK;
+    static const unsigned int ec_option_mask;
     // Selects nearest neighbor coding method.
-    static const unsigned int NN_OPTION_MASK;
+    static const unsigned int nn_option_mask;
 };
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/test/dataspace/simple_test.cpp
+++ b/test/dataspace/simple_test.cpp
@@ -98,7 +98,7 @@ SCENARIO("construction of a simple dataspace from dimensions") {
     }
 
     AND_GIVEN("maximum dimensions") {
-      Dimensions max = {100, 200, dataspace::Simple::UNLIMITED};
+      Dimensions max = {100, 200, dataspace::Simple::unlimited};
       THEN("we can construct a dataspace with maximum dimensions") {
         Simple space(dimensions, max);
         AND_THEN("the size is") { REQUIRE(space.size() == 10 * 20 * 30); }

--- a/test/filter/szip_test.cpp
+++ b/test/filter/szip_test.cpp
@@ -38,13 +38,13 @@ SCENARIO("using the SZIP filter") {
     }
   }
   GIVEN("a non-default instance") {
-    filter::SZip szip(filter::SZip::EC_OPTION_MASK, 16);
+    filter::SZip szip(filter::SZip::ec_option_mask, 16);
     THEN("the configuration will be") {
-      REQUIRE(szip.options_mask() == filter::SZip::EC_OPTION_MASK);
+      REQUIRE(szip.options_mask() == filter::SZip::ec_option_mask);
       REQUIRE(szip.pixels_per_block() == 16u);
       AND_THEN("we can set the mask to NN_OPTION_MASK") {
-        szip.options_mask(filter::SZip::NN_OPTION_MASK);
-        REQUIRE(szip.options_mask() == filter::SZip::NN_OPTION_MASK);
+        szip.options_mask(filter::SZip::nn_option_mask);
+        REQUIRE(szip.options_mask() == filter::SZip::nn_option_mask);
       }
       AND_THEN("we can set the pixels per block to 32") {
         szip.pixels_per_block(32);

--- a/test/node/chunked_dataset_test.cpp
+++ b/test/node/chunked_dataset_test.cpp
@@ -31,7 +31,7 @@ using namespace hdf5;
 SCENARIO("testing a chunked dataset") {
   auto f = file::create("chunked_dataset_test.h5", file::AccessFlags::Truncate);
   auto type = datatype::create<int>();
-  dataspace::Simple space{{0, 1024}, {dataspace::Simple::UNLIMITED, 1024}};
+  dataspace::Simple space{{0, 1024}, {dataspace::Simple::unlimited, 1024}};
 
   WHEN("using a constructor") {
     node::ChunkedDataset dataset(f.root(), "data", type, space, {1024, 1024});

--- a/test/node/dataset_direct_chunk_test.cpp
+++ b/test/node/dataset_direct_chunk_test.cpp
@@ -46,7 +46,7 @@ using UShorts = std::vector<unsigned short int>;
 static hdf5::dataspace::Simple unlimited_space(const hdf5::Dimensions& current) {
   using hdf5::dataspace::Simple;
   hdf5::Dimensions limits(current.size());
-  std::fill(std::begin(limits), std::end(limits), Simple::UNLIMITED);
+  std::fill(std::begin(limits), std::end(limits), Simple::unlimited);
 
   return Simple(current, limits);
 }

--- a/test/node/dataset_extent_test.cpp
+++ b/test/node/dataset_extent_test.cpp
@@ -45,7 +45,7 @@ SCENARIO("testing the extent of a dataset") {
   using node::resize_by;
   auto f = file::create("dataset_extent_test.h5", file::AccessFlags::Truncate);
   auto r = f.root();
-  dataspace::Simple inf_dataspace({0}, {dataspace::Simple::UNLIMITED});
+  dataspace::Simple inf_dataspace({0}, {dataspace::Simple::unlimited});
   dataspace::Simple fin_dataspace({0}, {4096});
 
   auto create_dataset = [&r](const hdf5::Path& p,

--- a/test/node/dataset_io_speed_test.cpp
+++ b/test/node/dataset_io_speed_test.cpp
@@ -83,7 +83,7 @@ class create {
   }
   static dataspace::Simple ds(Dimensions current) {
     Dimensions max(current.size());
-    std::fill(std::begin(max), std::end(max), dataspace::Simple::UNLIMITED);
+    std::fill(std::begin(max), std::end(max), dataspace::Simple::unlimited);
     return dataspace::Simple(current, max);
   }
 

--- a/test/node/dataset_partial_io_test.cpp
+++ b/test/node/dataset_partial_io_test.cpp
@@ -41,7 +41,7 @@ SCENARIO("writing and reading with selections") {
 
   auto dataspace =
       [](size_t size) {
-        return dataspace::Simple{{size}, {dataspace::Simple::UNLIMITED}};
+        return dataspace::Simple{{size}, {dataspace::Simple::unlimited}};
       };
 
   GIVEN("an empty dataset") {
@@ -101,7 +101,7 @@ SCENARIO("reading from empty datasets") {
   const std::string filename = "reading_from_empty_datasets.h5";
   auto f = file::create(filename, file::AccessFlags::Truncate);
   auto r = f.root();
-  dataspace::Simple space{{0}, {dataspace::Simple::UNLIMITED}};
+  dataspace::Simple space{{0}, {dataspace::Simple::unlimited}};
   property::LinkCreationList lcpl;
   property::DatasetCreationList dcpl;
   dcpl.chunk({1});


### PR DESCRIPTION
To avoid potential  interference with preprocessor  macros it would be good to change `static const` all-caps names to e.g. lower case names (similarly to #503) It resolves #528.  (If someone prefers camel than lower cases I can change to camel as well)