### PR TITLE
Issue 400d: move documentation of enumerators to the end of sections

### DIFF
--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -10,21 +10,20 @@ Dataspace related classes and functions
 
 .. doxygenclass:: hdf5::dataspace::Dataspace
    :members:
-   
-.. doxygenenum:: hdf5::dataspace::Type
-   
-   
+
 :cpp:class:`Scalar`
 -------------------
 
 .. doxygenclass:: hdf5::dataspace::Scalar
    :members:
-   
+
 :cpp:class:`Simple`
 -------------------
 
 .. doxygenclass:: hdf5::dataspace::Simple
    :members:
+
+
 
 Selection related classes and functions
 =======================================
@@ -34,13 +33,33 @@ Selection related classes and functions
 
 .. doxygenclass:: hdf5::dataspace::Selection
    :members:
-   
-.. doxygenenum:: hdf5::dataspace::SelectionType
-
-.. doxygenenum:: hdf5::dataspace::SelectionOperation
 
 :cpp:class:`Hyperslab`
 ----------------------
 
 .. doxygenclass:: hdf5::dataspace::Hyperslab
    :members:
+
+:cpp:class:`Points`
+-------------------
+
+.. doxygenclass:: hdf5::dataspace::Points
+   :members:
+
+Enumerations
+============
+
+:cpp:enum:`Type`
+----------------
+
+.. doxygenenum:: hdf5::dataspace::Type
+
+:cpp:enum:`SelectionType`
+-------------------------
+
+.. doxygenenum:: hdf5::dataspace::SelectionType
+
+:cpp:enum:`SelectionOperation`
+------------------------------
+
+.. doxygenenum:: hdf5::dataspace::SelectionOperation

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -8,8 +8,6 @@ Enumerations
 :cpp:enum:`Class`
 -----------------
 
-.. doxygenenum:: hdf5::datatype::Class
-
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Class &)
 
 :cpp:enum:`Order`
@@ -68,13 +66,13 @@ Classes
 
 .. doxygenclass:: hdf5::datatype::Datatype
    :members:
-   
+
 :cpp:class:`Array`
 ------------------
 
 .. doxygenclass:: hdf5::datatype::Array
    :members:
-   
+
 :cpp:class:`VLengthArray`
 -------------------------
 
@@ -83,25 +81,25 @@ Classes
 
 :cpp:class:`Compound`
 ---------------------
-   
+
 .. doxygenclass:: hdf5::datatype::Compound
    :members:
-   
+
 :cpp:class:`Float`
 ------------------
-   
+
 .. doxygenclass:: hdf5::datatype::Float
    :members:
 
 :cpp:class:`Integer`
 --------------------
-   
+
 .. doxygenclass:: hdf5::datatype::Integer
    :members:
 
 :cpp:class:`String`
 -------------------
-   
+
 .. doxygenclass:: hdf5::datatype::String
    :members:
 
@@ -110,3 +108,11 @@ Type traits
 
 .. doxygenclass:: hdf5::datatype::TypeTrait
    :members:
+
+Enumerations
+============
+
+:cpp:enum:`Class`
+-----------------
+
+.. doxygenenum:: hdf5::datatype::Class

--- a/doc/source/api_reference/namespace_node.rst
+++ b/doc/source/api_reference/namespace_node.rst
@@ -2,23 +2,6 @@
 Namespace :cpp:any:`hdf5::node`
 ===============================
 
-Enumerations
-============
-
-:cpp:enum:`NodeType`
---------------------
-
-.. doxygenenum:: hdf5::node::NodeType
-
-.. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const NodeType &)
-
-:cpp:enum:`LinkType`
---------------------
-
-.. doxygenenum:: hdf5::node::LinkType
-
-.. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const LinkType &)
-
 Classes
 =======
 
@@ -37,7 +20,7 @@ Classes
 
 .. doxygenclass:: hdf5::node::Link
    :members:
-   
+
 .. doxygenfunction:: hdf5::node::operator!=(const Link &, const Link &)
 
 .. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const Link &)
@@ -47,63 +30,63 @@ Classes
 
 .. doxygenclass:: hdf5::node::LinkTarget
    :members:
-   
+
 :cpp:class:`Group`
 ------------------
 
 .. doxygenclass:: hdf5::node::Group
    :members:
-   
+
 :cpp:class:`GroupView`
 ----------------------
 
 .. doxygenclass:: hdf5::node::GroupView
    :members:
-   
+
 :cpp:class:`NodeView`
 ---------------------
 
 .. doxygenclass:: hdf5::node::NodeView
    :members:
-   
+
 .. doxygenclass:: hdf5::node::NodeIterator
    :members:
-   
+
 .. doxygenclass:: hdf5::node::RecursiveNodeIterator
    :members:
-   
+
 :cpp:class:`LinkView`
 ---------------------
 
 .. doxygenclass:: hdf5::node::LinkView
    :members:
-   
+
 .. doxygenclass:: hdf5::node::LinkIterator
    :members:
-   
+
 .. doxygenclass:: hdf5::node::RecursiveLinkIterator
    :members:
-   
+
 :cpp:class:`Dataset`
 --------------------
 
 .. doxygenclass:: hdf5::node::Dataset
    :members:
-   
-   
+
+
 :cpp:class:`ChunkedDataset`
 ---------------------------
 
 .. doxygenclass:: hdf5::node::ChunkedDataset
    :members:
-   
-   
+
+
 :cpp:class:`VirtualDataset`
 ---------------------------
 
 .. doxygenclass:: hdf5::node::VirtualDataset
    :members:
-   
+
 Functions
 =========
 
@@ -167,5 +150,19 @@ Functions
 .. doxygenfunction:: hdf5::node::is_dataset
 
 
-   
- 
+Enumerations
+============
+
+:cpp:enum:`NodeType`
+--------------------
+
+.. doxygenenum:: hdf5::node::NodeType
+
+.. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const NodeType &)
+
+:cpp:enum:`LinkType`
+--------------------
+
+.. doxygenenum:: hdf5::node::LinkType
+
+.. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const LinkType &)

--- a/doc/source/users_guide/overview.rst
+++ b/doc/source/users_guide/overview.rst
@@ -114,12 +114,12 @@ represent the following HDF5 objects:
 +-----------------------------------+----------------------------+
 | :cpp:class:`hdf5::node::Group`    | an HDF5 group              |
 +-----------------------------------+----------------------------+
-| :cpp:class:`hdf5::node::Datatype` | an HDF5 committed datatype |
+| :any:`hdf5::node::Datatype`       | an HDF5 committed datatype |
 +-----------------------------------+----------------------------+
 
 .. important::
 
-   Do not confuse :cpp:class:`hdf5::node::Datatype` with
+   Do not confuse :any:`hdf5::node::Datatype` with
    :cpp:class:`hdf5::datatype::Datatype`. Thoug the former one is constructed
    from the latter one, the latter one cannot be accessed via a path.
    A committed datatype is a means to store complex datatype within a file.


### PR DESCRIPTION
It resolves rendering problems (#400) of the latest (master branch) documentation like
```
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_datatype.rst:75: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_datatype:11.
Declaration is '.. cpp:class:: hdf5::datatype::Array : public hdf5::datatype::Datatype'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_datatype.rst:87: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_datatype:11.
Declaration is '.. cpp:class:: hdf5::datatype::Compound : public hdf5::datatype::Datatype'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_datatype.rst:93: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_datatype:11.
Declaration is '.. cpp:class:: hdf5::datatype::Float : public hdf5::datatype::Datatype'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_datatype.rst:99: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_datatype:11.
Declaration is '.. cpp:class:: hdf5::datatype::Integer : public hdf5::datatype::Datatype'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_datatype.rst:105: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_datatype:11.
Declaration is '.. cpp:class:: hdf5::datatype::String : public hdf5::datatype::Datatype'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_node.rst:54: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_node:11.
Declaration is '.. cpp:class:: hdf5::node::Group : public hdf5::node::Node'.
/home/jkotan/sources/h5cpp-build/doc/source/api_reference/namespace_node.rst:90: WARNING: Duplicate C++ declaration, also defined at api_reference/namespace_node:11.
Declaration is '.. cpp:class:: hdf5::node::Dataset : public hdf5::node::Node'.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] users_guide/using                                                                                                                                                
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/dataspace_selections.rst:20: WARNING: cpp:class targets a enumerator (hdf5::dataspace::Points).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/files.rst:182: WARNING: cpp:class targets a enumerator (hdf5::node::Group).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/files.rst:187: WARNING: cpp:class targets a enumerator (hdf5::node::Group).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/overview.rst:114: WARNING: cpp:class targets a enumerator (hdf5::node::Dataset).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/overview.rst:116: WARNING: cpp:class targets a enumerator (hdf5::node::Group).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/overview.rst:118: WARNING: cpp:class targets a enumerator (hdf5::node::Datatype).
/home/jkotan/sources/h5cpp-build/doc/source/users_guide/overview.rst:122: WARNING: cpp:class targets a enumerator (hdf5::node::Datatype).
```
I helps to  `breathe` to get the correct links by
- moving documentation of enumerators to the end of the corresponding sections
- adding the section subtitles with `:cpp:enum:`  and enumerator names
- changing `:cpp:class:` for `hdf5::node::Datatype` to `:any:` (`hdf5::node::Datatype` is not added to h5cpp yet so it cannot be found )

After merging the PR there is no more warnings in the documentation built of the latest version.