### PR TITLE
Issue 535: move documentation versions links to the sidebar

### DIFF
--- a/doc/source/_templates/CMakeLists.txt
+++ b/doc/source/_templates/CMakeLists.txt
@@ -1,1 +1,2 @@
 configure_file(layout.html.in layout.html @ONLY)
+configure_file(versions.html versions.html COPYONLY)

--- a/doc/source/_templates/versions.html
+++ b/doc/source/_templates/versions.html
@@ -1,0 +1,14 @@
+<p>
+  <h3 class='versions'>{{ ('Versions') }}</h3>
+  <p>
+    <ul>
+      <li><a class="reference external" href="../latest/index.html">v:latest</a></li>
+      <li><a class="reference external" href="../stable/index.html">v:stable</a></li>
+      {% if docs_versions %}
+      {%- for ver in docs_versions %}
+      <li><a class="reference external" href="../{{ ver }}/index.html">{{ ver }}</a></li>
+      {%- endfor %}
+      {% endif %}
+    </ul>
+  </p>
+</p>

--- a/doc/source/_templates/versions.html
+++ b/doc/source/_templates/versions.html
@@ -2,11 +2,11 @@
   <h3 class='versions'>{{ ('Versions') }}</h3>
   <p>
     <ul>
-      <li><a class="reference external" href="../latest/index.html">v:latest</a></li>
-      <li><a class="reference external" href="../stable/index.html">v:stable</a></li>
+      <li><a class="reference external" href="{{ pathto(master_doc, 1)|e }}/../../latest/index.html">v:latest</a></li>
+      <li><a class="reference external" href="{{ pathto(master_doc, 1)|e }}/../../stable/index.html">v:stable</a></li>
       {% if docs_versions %}
       {%- for ver in docs_versions %}
-      <li><a class="reference external" href="../{{ ver }}/index.html">{{ ver }}</a></li>
+      <li><a class="reference external" href="{{ pathto(master_doc, 1)|e }}/../../{{ ver }}/index.html">{{ ver }}</a></li>
       {%- endfor %}
       {% endif %}
     </ul>

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -2,6 +2,57 @@
 Namespace :cpp:any:`hdf5::datatype`
 ===================================
 
+Classes
+=======
+
+:cpp:class:`Datatype`
+---------------------
+
+.. doxygenclass:: hdf5::datatype::Datatype
+   :members:
+
+:cpp:class:`Array`
+------------------
+
+.. doxygenclass:: hdf5::datatype::Array
+   :members:
+
+:cpp:class:`VLengthArray`
+-------------------------
+
+.. doxygenclass:: hdf5::datatype::VLengthArray
+   :members:
+
+:cpp:class:`Compound`
+---------------------
+
+.. doxygenclass:: hdf5::datatype::Compound
+   :members:
+
+:cpp:class:`Float`
+------------------
+
+.. doxygenclass:: hdf5::datatype::Float
+   :members:
+
+:cpp:class:`Integer`
+--------------------
+
+.. doxygenclass:: hdf5::datatype::Integer
+   :members:
+
+:cpp:class:`String`
+-------------------
+
+.. doxygenclass:: hdf5::datatype::String
+   :members:
+
+Type traits
+===========
+
+.. doxygenclass:: hdf5::datatype::TypeTrait
+   :members:
+
 Enumerations
 ============
 
@@ -57,60 +108,6 @@ Enumerations
 .. doxygenenum:: hdf5::datatype::CharacterEncoding
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const CharacterEncoding &)
-
-Classes
-=======
-
-:cpp:class:`Datatype`
----------------------
-
-.. doxygenclass:: hdf5::datatype::Datatype
-   :members:
-
-:cpp:class:`Array`
-------------------
-
-.. doxygenclass:: hdf5::datatype::Array
-   :members:
-
-:cpp:class:`VLengthArray`
--------------------------
-
-.. doxygenclass:: hdf5::datatype::VLengthArray
-   :members:
-
-:cpp:class:`Compound`
----------------------
-
-.. doxygenclass:: hdf5::datatype::Compound
-   :members:
-
-:cpp:class:`Float`
-------------------
-
-.. doxygenclass:: hdf5::datatype::Float
-   :members:
-
-:cpp:class:`Integer`
---------------------
-
-.. doxygenclass:: hdf5::datatype::Integer
-   :members:
-
-:cpp:class:`String`
--------------------
-
-.. doxygenclass:: hdf5::datatype::String
-   :members:
-
-Type traits
-===========
-
-.. doxygenclass:: hdf5::datatype::TypeTrait
-   :members:
-
-Enumerations
-============
 
 :cpp:enum:`Class`
 -----------------

--- a/doc/source/conf.py.in
+++ b/doc/source/conf.py.in
@@ -184,7 +184,19 @@ html_static_path = ['_static']
 
 # Custom sidebar templates, maps document names to template names.
 #
-# html_sidebars = {}
+html_sidebars = {
+    '**': [
+        'localtoc.html',
+        'relations.html',
+        'searchbox.html',
+        # located at _templates/
+        'versions.html',
+    ]
+}
+
+html_context = {
+    "docs_versions" : ["v0.4.1", "v0.3.3"]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/source/index.rst.in
+++ b/doc/source/index.rst.in
@@ -26,10 +26,3 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-Documentation for other h5cpp versions
-======================================
-
-`v:latest <../latest/index.html>`_,
-`v:stable <../stable/index.html>`_,
-`v0.4.1 <../v0.4.1/index.html>`_,
-`v0.3.3 <../v0.3.3/index.html>`_


### PR DESCRIPTION
It resolves #535 by moving documentation versions links to the sidebar making use of sphinx templates. 
It also reorder datatype enumerators documentation to one block.
With the PR the visible documentation versions can be selected  in the `html_context.docs_versions` list defined in `conf.py.in`.