### PR TITLE
Issue 221: add type(), size() and dimensions() to Selection class

### DIFF
--- a/src/h5cpp/dataspace/hyperslab.cpp
+++ b/src/h5cpp/dataspace/hyperslab.cpp
@@ -186,6 +186,29 @@ void Hyperslab::apply(const Dataspace &space, SelectionOperation ops) const {
   }
 }
 
+SelectionType Hyperslab::type() const {
+  return SelectionType::Hyperslab;
+}
+
+size_t Hyperslab::size() const {
+  if(rank() == 0)
+    return 0;
+  size_t size = 1ul;
+  Dimensions dims = block();
+  Dimensions cnt = count();
+  for(Dimensions::size_type i = 0; i != dims.size(); i++)
+    size *= dims[i] * cnt[i];
+  return size;
+}
+
+Dimensions Hyperslab::dimensions() const {
+  Dimensions dims = block();
+  Dimensions cnt = count();
+  for(Dimensions::size_type i = 0; i != dims.size(); i++)
+    dims[i] *= cnt[i];
+  return dims;
+}
+
 Dataspace operator||(const Dataspace &space, const Hyperslab &selection) {
   Dataspace new_space(space);
   new_space.selection(SelectionOperation::Set, selection);

--- a/src/h5cpp/dataspace/hyperslab.hpp
+++ b/src/h5cpp/dataspace/hyperslab.hpp
@@ -250,6 +250,38 @@ class DLL_EXPORT Hyperslab : public Selection {
   virtual void apply(const Dataspace &space,
                      SelectionOperation ops) const override;
 
+  //!
+  //! \brief get current dimensions
+  //!
+  //! Get a number of elements along each dimension a selection spans
+  //! this is particularly useful in the case of a Hyperslab 
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  //! \return the selection dimentsions
+  //!
+  virtual Dimensions dimensions() const override;
+
+  //!
+  //! \brief get the selection size
+  //!
+  //! Get the total number of elements adressed by an individual selection
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  //! \return the selection type enumerator
+  //!
+  virtual size_t size() const override;
+
+  //!
+  //! \brief get the selection type
+  //!
+  //! Get the type of the selection
+  //!
+  //! \return the selection type enumerator
+  //!
+  virtual SelectionType type() const override;
+
  private:
   inline void check_dimension_index(size_t index, const std::string &what) const {
     if (index >= rank()) {

--- a/src/h5cpp/dataspace/points.cpp
+++ b/src/h5cpp/dataspace/points.cpp
@@ -27,6 +27,7 @@
 #include <h5cpp/dataspace/points.hpp>
 #include <h5cpp/error/error.hpp>
 #include <sstream>
+#include <set>
 
 namespace hdf5
 {
@@ -88,5 +89,27 @@ void Points::apply(const Dataspace& space,
 
 }
 
+SelectionType Points::type() const {
+  return SelectionType::Points;
+}
+
+size_t Points::size() const {
+  return points();
+}
+
+Dimensions Points::dimensions() const {
+  size_t rnk = rank(); 
+  if(rnk == 0)
+    throw std::runtime_error("Cannot get coordinates for empty Points selection");
+  Dimensions dims(rnk);
+  std::vector<std::set<hsize_t>> uniqdim(rnk);
+  
+  for(size_t j = 0; j != coordinates_.size(); j++)
+    uniqdim[j % rnk].insert(coordinates_[j]);
+  for(Dimensions::size_type i = 0; i != dims.size(); i++)
+    dims[i] = uniqdim[i].size();
+  return dims;
+}
+  
 } // namespace dataspace
 } // namespace hdf5

--- a/src/h5cpp/dataspace/points.hpp
+++ b/src/h5cpp/dataspace/points.hpp
@@ -112,6 +112,38 @@ class DLL_EXPORT Points : public Selection
     //!
     void apply (const Dataspace &space, SelectionOperation ops) const override;
 
+    //!
+    //! \brief get the selection size
+    //!
+    //! Get the total number of elements adressed by an individual selection
+    //!
+    //! \throws std::runtime_error in case of a failure
+    //!
+    //! \return the selection type enumerator
+    //!
+    virtual size_t size() const override;
+
+    //!
+    //! \brief get the selection type
+    //!
+    //! Get the type of the selection
+    //!
+    //! \return the selection type enumerator
+    //!
+    virtual SelectionType type() const override;
+
+    //!
+    //! \brief get current dimensions
+    //!
+    //! Get a number of elements along each dimension a selection spans
+    //! this is particularly useful in the case of a Hyperslab 
+    //!
+    //! \throws std::runtime_error in case of a failure
+    //!
+    //! \return the selection dimentsions
+    //!
+    virtual Dimensions dimensions() const override;
+
   private:
     size_t rank_{ 0 };
 #ifdef _MSC_VER

--- a/src/h5cpp/dataspace/selection.cpp
+++ b/src/h5cpp/dataspace/selection.cpp
@@ -41,14 +41,5 @@ Dataspace operator||(const Dataspace &space, const SelectionList &selections) {
   return new_space;
 }
 
-SelectionType Selection::type() const {
-  return SelectionType::None;
-}
-
-size_t Selection::size() const {
-  return 0ul;
-}
-
-
 } // namespace dataspace
 } // namespace hdf5

--- a/src/h5cpp/dataspace/selection.cpp
+++ b/src/h5cpp/dataspace/selection.cpp
@@ -41,5 +41,14 @@ Dataspace operator||(const Dataspace &space, const SelectionList &selections) {
   return new_space;
 }
 
+SelectionType Selection::type() const {
+  return SelectionType::None;
+}
+
+size_t Selection::size() const {
+  return 0ul;
+}
+
+
 } // namespace dataspace
 } // namespace hdf5

--- a/src/h5cpp/dataspace/selection.hpp
+++ b/src/h5cpp/dataspace/selection.hpp
@@ -102,7 +102,7 @@ class DLL_EXPORT Selection {
   //!
   //! \return the selection type enumerator
   //!
-  virtual size_t size() const;
+  virtual size_t size() const = 0;
 
   //!
   //! \brief get the selection type
@@ -111,7 +111,7 @@ class DLL_EXPORT Selection {
   //!
   //! \return the selection type enumerator
   //!
-  virtual SelectionType type() const;
+  virtual SelectionType type() const = 0;
 };
 
 struct OperationWithSelection {

--- a/src/h5cpp/dataspace/selection.hpp
+++ b/src/h5cpp/dataspace/selection.hpp
@@ -81,6 +81,37 @@ class DLL_EXPORT Selection {
   //! \param ops operator for the selection
   virtual void apply(const Dataspace &space,
                      SelectionOperation ops) const = 0;
+  //!
+  //! \brief get current dimensions
+  //!
+  //! Get a number of elements along each dimension a selection spans
+  //! this is particularly useful in the case of a Hyperslab 
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  //! \return the selection dimentsions
+  //!
+  virtual Dimensions dimensions() const = 0;
+
+  //!
+  //! \brief get the selection size
+  //!
+  //! Get the total number of elements adressed by an individual selection
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //!
+  //! \return the selection type enumerator
+  //!
+  virtual size_t size() const;
+
+  //!
+  //! \brief get the selection type
+  //!
+  //! Get the type of the selection
+  //!
+  //! \return the selection type enumerator
+  //!
+  virtual SelectionType type() const;
 };
 
 struct OperationWithSelection {

--- a/test/dataspace/hyperslab_simple_test.cpp
+++ b/test/dataspace/hyperslab_simple_test.cpp
@@ -36,6 +36,13 @@ SCENARIO("Hyperslab construction") {
   GIVEN("a default constructed hyperslab") {
     dataspace::Hyperslab h;
     THEN("the rank would be 0") { REQUIRE(h.rank() == 0ul); }
+    THEN("the size must be 0") { REQUIRE(h.size() == 0ul); }
+    THEN("the type must be Hyperslab") {
+      REQUIRE(h.type() == hdf5::dataspace::SelectionType::Hyperslab);
+    }
+    THEN("dimensions access must fail") {
+      REQUIRE_THROWS_AS(h.dimensions(), std::runtime_error);
+    }
     THEN("offset access must fail") {
       REQUIRE_THROWS_AS(h.offset(), std::runtime_error);
     }
@@ -53,15 +60,27 @@ SCENARIO("Hyperslab construction") {
   GIVEN("a hyperslab constructed from the number of dimensions") {
     dataspace::Hyperslab hyperslab(2);
     THEN("the rank must be 2") { REQUIRE(hyperslab.rank() == 2ul); }
+    THEN("the size must be 0") { REQUIRE(hyperslab.size() == 0ul); }
+    THEN("the type must be Hyperslab") {
+      REQUIRE(hyperslab.type() == hdf5::dataspace::SelectionType::Hyperslab);
+    }
+    THEN("dimensions access be 0") {
+      REQUIRE_THAT(hyperslab.dimensions(),
+                   Catch::Matchers::Equals(Dimensions{0, 0}));
+    }
+    THEN("all offset must be 0") {
+      REQUIRE_THAT(hyperslab.offset(),
+                   Catch::Matchers::Equals(Dimensions{0, 0}));
+    }
     THEN("all strides must be 1") {
       REQUIRE_THAT(hyperslab.stride(),
                    Catch::Matchers::Equals(Dimensions{1, 1}));
     }
-    THEN("all counts must be 1") {
+    THEN("all counts must be 0") {
       REQUIRE_THAT(hyperslab.count(),
                    Catch::Matchers::Equals(Dimensions{0, 0}));
     }
-    THEN("all blocks must be 1") {
+    THEN("all blocks must be 0") {
       REQUIRE_THAT(hyperslab.block(),
                    Catch::Matchers::Equals(Dimensions{0, 0}));
     }
@@ -74,6 +93,14 @@ SCENARIO("Hyperslab construction") {
       THEN("a hyperslab can be constructed") {
         dataspace::Hyperslab h(offset, block);
         AND_THEN("the rank will be 2") { REQUIRE(h.rank() == 2); }
+	AND_THEN("the size must be 12") { REQUIRE(h.size() == 12ul); }
+	AND_THEN("the type must be Hyperslab") {
+	  REQUIRE(h.type() == hdf5::dataspace::SelectionType::Hyperslab);
+	}
+	AND_THEN("dimensions access be {3,4}") {
+	  REQUIRE_THAT(h.dimensions(),
+		       Catch::Matchers::Equals(Dimensions{3, 4}));
+        }
         AND_THEN("the offset will be {1,2}") {
           REQUIRE_THAT(h.offset(), Catch::Matchers::Equals(Dimensions{1, 2}));
         }
@@ -95,6 +122,14 @@ SCENARIO("Hyperslab construction") {
         THEN("a hyperslab can be constructed") {
           dataspace::Hyperslab h(offset, count, stride);
           AND_THEN("the ranke will be 2") { REQUIRE(h.rank() == 2); }
+	  AND_THEN("the size must be 12") { REQUIRE(h.size() == 12ul); }
+	  AND_THEN("the type must be Hyperslab") {
+	    REQUIRE(h.type() == hdf5::dataspace::SelectionType::Hyperslab);
+	  }
+	  AND_THEN("dimensions access be {3,4} ") {
+	    REQUIRE_THAT(h.dimensions(),
+			 Catch::Matchers::Equals(Dimensions{3, 4}));
+	  }
           AND_THEN("the offset will be {1,2}") {
             REQUIRE_THAT(h.offset(), Catch::Matchers::Equals(Dimensions{1, 2}));
           }
@@ -119,6 +154,14 @@ SCENARIO("Hyperslab construction") {
           THEN("a hyperslab can be constructed with") {
             dataspace::Hyperslab h(offset, block, count, stride);
             AND_THEN("the rank will be 2") { REQUIRE(h.rank() == 2); }
+	    AND_THEN("the size must be 360") { REQUIRE(h.size() == 360ul); }
+	    AND_THEN("the type must be Hyperslab") {
+	      REQUIRE(h.type() == hdf5::dataspace::SelectionType::Hyperslab);
+	    }
+	    AND_THEN("dimensions access be {15,24} ") {
+	      REQUIRE_THAT(h.dimensions(),
+			   Catch::Matchers::Equals(Dimensions{15, 24}));
+	    }
             AND_THEN("the offset will be {1,2}") {
               REQUIRE_THAT(h.offset(),
                            Catch::Matchers::Equals(Dimensions{1, 2}));

--- a/test/dataspace/points_simple_test.cpp
+++ b/test/dataspace/points_simple_test.cpp
@@ -36,17 +36,40 @@ SCENARIO("construction of point selections") {
   GIVEN("a default constructed Points") {
     dataspace::Points h;
     THEN("the rank must be 0") { REQUIRE(h.rank() == 0); }
+    THEN("the size must be 0") { REQUIRE(h.size() == 0ul); }
+    THEN("the type must be Points") {
+      REQUIRE(h.type() == hdf5::dataspace::SelectionType::Points);
+    }
+    THEN("dimensions access must fail") {
+      REQUIRE_THROWS_AS(h.dimensions(), std::runtime_error);
+    }
   }
 
   GIVEN("a Point selection constructed for a rank 2") { 
     dataspace::Points h(2);
     THEN("the rank must be 2") { REQUIRE(h.rank() == 2); }
+    THEN("the size must be 0") { REQUIRE(h.size() == 0ul); }
+    THEN("the type must be Points") {
+      REQUIRE(h.type() == hdf5::dataspace::SelectionType::Points);
+    }
+    THEN("dimensions access be 0") {
+      REQUIRE_THAT(h.dimensions(),
+                   Catch::Matchers::Equals(Dimensions{0, 0}));
+    }
   }
 
   GIVEN("a Point selection constructed from a list of points") { 
     dataspace::Points points({{1, 1}, {2, 2}});
     THEN("the rank must be 2") { REQUIRE(points.rank() == 2u); }
     THEN("the number of points must be 2") { REQUIRE(points.points() == 2u); }
+    THEN("the size must be 2") { REQUIRE(points.size() == 2ul); }
+    THEN("the type must be Points") {
+      REQUIRE(points.type() == hdf5::dataspace::SelectionType::Points);
+    }
+    THEN("dimensions access be {2,2}") {
+      REQUIRE_THAT(points.dimensions(),
+                   Catch::Matchers::Equals(Dimensions{2, 2}));
+    }
   }
 
   GIVEN("a list of points of different rank") {


### PR DESCRIPTION
It resolves #221 by adding  virtual `type()`, `size()` and `dimensions()` methods to `Selection` class and implementing them in `Hyperslab` and `Points` classes.