### PR TITLE
Issue 554: add an information to documentation for which version of hdf5 a class or a method is accessible

### DIFF
--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -47,6 +47,12 @@ Classes
 .. doxygenclass:: hdf5::datatype::String
    :members:
 
+:cpp:class:`Enum`
+-----------------
+
+.. doxygenclass:: hdf5::datatype::Enum
+   :members:
+
 Type traits
 ===========
 

--- a/doc/source/api_reference/namespace_filter.rst
+++ b/doc/source/api_reference/namespace_filter.rst
@@ -6,12 +6,24 @@ Namespace :cpp:any:`hdf5::filter`
 
 .. doxygenclass:: hdf5::filter::Filter
    :members:
-   
+
 .. doxygenclass:: hdf5::filter::Deflate
    :members:
-   
+
 .. doxygenclass:: hdf5::filter::Shuffle
    :members:
-   
+
 .. doxygenclass:: hdf5::filter::Fletcher32
+   :members:
+
+.. doxygenclass:: hdf5::filter::SZip
+   :members:
+
+.. doxygenclass:: hdf5::filter::NBit
+   :members:
+
+.. doxygenclass:: hdf5::filter::ScaleOffset
+   :members:
+
+.. doxygenclass:: hdf5::filter::ExternalFilter
    :members:

--- a/doc/source/api_reference/namespace_property.rst
+++ b/doc/source/api_reference/namespace_property.rst
@@ -49,6 +49,14 @@ Enumerations
 
 .. doxygenfunction:: hdf5::property::operator|(const CopyFlag &, const CopyFlag &)
 
+:cpp:enum:`VirtualDataView`
+---------------------------
+
+.. doxygenenum:: hdf5::property::VirtualDataView
+
+.. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const VirtualDataView &)
+
+
 Classes
 =======
 

--- a/src/h5cpp/core/object_id.hpp
+++ b/src/h5cpp/core/object_id.hpp
@@ -94,6 +94,9 @@ class DLL_EXPORT ObjectId
     //!
     bool operator< (const ObjectId& other) const;
 
+    //!
+    //! @brief stream output operator for ObjectId class
+    //!
     DLL_EXPORT friend std::ostream & operator<<(std::ostream &os, const ObjectId& p);
 
     //!
@@ -132,7 +135,7 @@ class DLL_EXPORT ObjectId
     //! Obtains the name of the file where the object is stored in.
     static std::string get_file_name(const ObjectHandle &handle);
 
-#if (defined(_DOXYGEN_) || H5_VERSION_LE(1,10,6))
+#if H5_VERSION_LE(1,10,6)
 #define H5O_info_t_ H5O_info_t
 #else
 #define H5O_info_t_ H5O_info1_t

--- a/src/h5cpp/file/direct_driver.hpp
+++ b/src/h5cpp/file/direct_driver.hpp
@@ -31,7 +31,7 @@ namespace hdf5 {
 namespace file {
 
 //!
-//! \brief direct write without buffering
+//! \brief direct write without buffering (*for hdf5 compiled with H5_HAVE_DIRECT*)
 //!
 class DLL_EXPORT DirectDriver : public Driver
 {

--- a/src/h5cpp/file/mpi_driver.hpp
+++ b/src/h5cpp/file/mpi_driver.hpp
@@ -32,6 +32,9 @@ namespace file {
 
 #if ( defined(_DOXYGEN_) || defined(WITH_MPI) )
 
+//!
+//! \brief class for the MPI driver (*for hdf5 with compiled MPI*)
+//!
 class DLL_EXPORT MPIDriver : public Driver
 {
   public:

--- a/src/h5cpp/file/types.hpp
+++ b/src/h5cpp/file/types.hpp
@@ -43,7 +43,9 @@ enum class AccessFlags : unsigned
   ReadWrite = 0x0001,
   ReadOnly  = 0x0000,
 #if ( defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0) )
+  //! (*since hdf5 1.10.0*)
   SWMRRead = 0x0040,
+  //! (*since hdf5 1.10.0*)
   SWMRWrite = 0x0020
 #endif
 };

--- a/src/h5cpp/node/dataset.hpp
+++ b/src/h5cpp/node/dataset.hpp
@@ -194,7 +194,7 @@ class DLL_EXPORT Dataset : public Node
 
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0))
     //!
-    //! \brief refresh the dataset
+    //! \brief refresh the dataset (*since hdf5 1.10.0*)
     //!
     //!
     //! \throws std::runtime_error in case of a failure
@@ -381,7 +381,7 @@ class DLL_EXPORT Dataset : public Node
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,2))
 
     //!
-    //! \brief read dataset chunk
+    //! \brief read dataset chunk  (*since hdf5 1.10.2*)
     //!
     //! Read a chunk from a dataset to an instance of T.
     //!
@@ -901,7 +901,7 @@ void Dataset::write_chunk(const T &data,
 
   if(mem_type.get_class() == datatype::Class::Integer)
     {
-#if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,3))
+#if H5_VERSION_GE(1,10,3)
       if(H5Dwrite_chunk(static_cast<hid_t>(*this),
                          static_cast<hid_t>(dtpl),
                          filter_mask,
@@ -935,7 +935,7 @@ void Dataset::write_chunk(const T &data,
     }
 }
 
-#if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,2))
+#if H5_VERSION_GE(1,10,2)
 
 template<typename T>
 std::uint32_t Dataset::read_chunk(T &data,
@@ -955,7 +955,7 @@ std::uint32_t Dataset::read_chunk(T &data,
   std::uint32_t filter_mask;
   if(mem_type.get_class() == datatype::Class::Integer)
     {
-#if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,3))
+#if H5_VERSION_GE(1,10,3)
       if(H5Dread_chunk(static_cast<hid_t>(*this),
 		       static_cast<hid_t>(dtpl),
 		       offset.data(),

--- a/src/h5cpp/node/group.hpp
+++ b/src/h5cpp/node/group.hpp
@@ -98,9 +98,9 @@ class DLL_EXPORT Group : public Node
 
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0))
     //!
-    //! \brief flush the group
+    //! \brief flush the group (*since hdf5 1.10.0*)
     //!
-    //! \throws std::runtime_error in case of a failure
+    //! \throws std::runtime_error in case of a failure)
     //!
     void flush() const;
 #endif

--- a/src/h5cpp/property/dataset_access.hpp
+++ b/src/h5cpp/property/dataset_access.hpp
@@ -59,6 +59,9 @@ class DLL_EXPORT ChunkCacheParameters {
 };
 
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0))
+//!
+//! \brief virtual data view enumeration (*since hdf5 1.10.0*)
+//!
 enum class VirtualDataView : std::underlying_type<H5D_vds_view_t>::type {
   FirstMissing = H5D_VDS_FIRST_MISSING,
   LastAvailable = H5D_VDS_LAST_AVAILABLE
@@ -108,7 +111,7 @@ class DLL_EXPORT DatasetAccessList : public LinkAccessList {
 
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0))
   //!
-  //! \brief missing data handling for virtual datasets
+  //! \brief missing data handling for virtual datasets (*since hdf5 1.10.0*)
   //!
   //! \throws std::runtime_error in case of a failure
   //! \param view set missing data strategy
@@ -116,7 +119,7 @@ class DLL_EXPORT DatasetAccessList : public LinkAccessList {
   void virtual_view(VirtualDataView view) const;
 
   //!
-  //! \brief get missing data strategy for virtual datasets
+  //! \brief get missing data strategy for virtual datasets (*since hdf5 1.10.0*)
   //!
   VirtualDataView virtual_view() const;
 

--- a/src/h5cpp/property/dataset_creation.hpp
+++ b/src/h5cpp/property/dataset_creation.hpp
@@ -98,6 +98,7 @@ enum class DatasetLayout : std::underlying_type<H5D_layout_t>::type {
   Contiguous = H5D_CONTIGUOUS,
   Chunked = H5D_CHUNKED,
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,0))
+  //! (*since hdf5 1.10.0*)
   Virtual = H5D_VIRTUAL
 #endif
 };

--- a/src/h5cpp/property/dataset_transfer.hpp
+++ b/src/h5cpp/property/dataset_transfer.hpp
@@ -91,10 +91,22 @@ class DLL_EXPORT DatasetTransferList : public List {
   }
 
 #if (defined(_DOXYGEN_) || defined(WITH_MPI) )
+  //!
+  //! \brief set mpi transfer mode (*for hdf5 compiled with MPI*)
+  //!
   void mpi_transfer_mode(MPITransferMode mode) const;
+  //!
+  //! \brief get mpi transfer mode (*for hdf5 compiled with MPI*)
+  //!
   MPITransferMode mpi_transfer_mode() const;
 
+  //!
+  //! \brief set mpi chunk option (*for hdf5 compiled with MPI*)
+  //!
   void mpi_chunk_option(MPIChunkOption option) const;
+  //!
+  //! \brief get mpi chunk option (*for hdf5 compiled with MPI*)
+  //!
   MPIChunkOption mpi_chunk_option() const;
 
 

--- a/src/h5cpp/property/file_creation.hpp
+++ b/src/h5cpp/property/file_creation.hpp
@@ -32,33 +32,90 @@
 namespace hdf5 {
 namespace property {
 
+//!
+//! \brief dataset creation property list
+//!
 class DLL_EXPORT FileCreationList : public GroupCreationList {
  public:
+  //!
+  //! \brief default constructor
+  //!
   FileCreationList();
   ~FileCreationList() override;
 
+  //!
+  //! \brief constructor
+  //!
+  //! Construct a file creation property list from a handler instance.
+  //! This constructor will throw an exception if the handle does not
+  //! reference a file creation property list.
+  //!
+  //! \throws std::runtime_error in case of a failure
+  //! \param handle r-value reference to a handle instance
+  //!
   explicit FileCreationList(ObjectHandle &&handle);
 
+  //!
+  //! \brief set user block
+  //!
   void user_block(hsize_t size) const;
+  //!
+  //! \brief get user block
+  //!
   hsize_t user_block() const;
 
+  //!
+  //! \brief set object offset size
+  //!
   void object_offset_size(size_t size) const;
+  //!
+  //! \brief get object offset size
+  //!
   size_t object_offset_size() const;
 
+  //!
+  //! \brief set object length size
+  //!
   void object_length_size(size_t size) const;
+  //!
+  //! \brief get object length size
+  //!
   size_t object_length_size() const;
 
+  //!
+  //! \brief set btree rank
+  //!
   void btree_rank(unsigned int ik);
+  //!
+  //! \brief get btree rank
+  //!
   unsigned int btree_rank() const;
 
+  //!
+  //! \brief set btree symbols
+  //!
   void btree_symbols(unsigned int lk);
+  //!
+  //! \brief get btree symbols
+  //!
   unsigned int btree_symbols() const;
-
+  //!
+  //! \brief set chunk tree rank
+  //!
   void chunk_tree_rank(unsigned int ik);
+  //!
+  //! \brief get chunk tree rank
+  //!
   unsigned int chunk_tree_rank() const;
 
 #if (defined(_DOXYGEN_) || H5_VERSION_GE(1,10,1))
+  //!
+  //! \brief set page size (*since hdf5 1.10.1*)
+  //!
   void page_size(hsize_t size);
+  //!
+  //!  \brief get page size (*since hdf5 1.10.1*)
+  //!
   hsize_t page_size() const;
 #endif
 


### PR DESCRIPTION
It resolves #554 by adding an information to documentation for which version of hdf5 a class or a method is accessible