### PR TITLE
Issue 556: add missing classes and functions to the sphinx API reference documentation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ import ecdcpipeline.PipelineBuilder
 project = "h5cpp"
 // coverage_os = "centos7-release"
 coverage_os = "None"
-documentation_os = "debian10-release"
+// documentation_os = "debian10-release"
+documentation_os = "ubuntu2004-release"
 
 container_build_nodes = [
   'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ builders = pipeline_builder.createBuilders { container ->
   if (container.key == documentation_os) {
     pipeline_builder.stage("Documentation") {
       container.sh """
-        pip3 --proxy=${http_proxy} install --user sphinx==4.0.3 breathe
+        pip3 --proxy=${http_proxy} install --user sphinx==3.4.3 breathe=4.26.0
         export PATH=$PATH:~/.local/bin:/bin
         cd build
         make html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ builders = pipeline_builder.createBuilders { container ->
   if (container.key == documentation_os) {
     pipeline_builder.stage("Documentation") {
       container.sh """
-        pip3 --proxy=${http_proxy} install --user sphinx==3.4.3 breathe==4.26.0
+        pip3 --proxy=${http_proxy} install --user sphinx==4.0.3 breathe
         export PATH=$PATH:~/.local/bin:/bin
         cd build
         make html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ builders = pipeline_builder.createBuilders { container ->
   if (container.key == documentation_os) {
     pipeline_builder.stage("Documentation") {
       container.sh """
-        pip3 --proxy=${http_proxy} install --user sphinx==3.4.3 breathe=4.26.0
+        pip3 --proxy=${http_proxy} install --user sphinx==3.4.3 breathe==4.26.0
         export PATH=$PATH:~/.local/bin:/bin
         cd build
         make html

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ def get_macos_pipeline(build_type)
 
                 dir("${project}/build") {
                     try {
-                        sh "cmake -DCMAKE_BUILD_TYPE=${build_type} ../code"
+                        sh "cmake -DCMAKE_BUILD_TYPE=${build_type} -DCONAN_FILE=conanfile_macos.txt  ../code"
                     } catch (e) {
                         failure_function(e, 'MacOSX / CMake failed')
                     }

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -3,10 +3,6 @@ boost/1.69.0
 hdf5/1.10.6
 zlib/1.2.11
 bzip2/1.0.8
-doxygen/1.9.1
-# m4/1.4.19
-# bison/3.7.6
-# flex/2.6.4
 
 [generators]
 cmake_paths

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -3,7 +3,8 @@ boost/1.69.0
 hdf5/1.10.6
 zlib/1.2.11
 bzip2/1.0.8
-doxygen/1.9.1
+doxygen/1.9.2
+m4/1.4.19
 
 [generators]
 cmake_paths

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -3,7 +3,7 @@ boost/1.69.0
 hdf5/1.10.6
 zlib/1.2.11
 bzip2/1.0.8
-doxygen/1.9.2
+doxygen/1.9.1
 
 [generators]
 cmake_paths

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -3,6 +3,7 @@ boost/1.69.0
 hdf5/1.10.6
 zlib/1.2.11
 bzip2/1.0.8
+doxygen/1.9.2
 
 [generators]
 cmake_paths

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -5,6 +5,8 @@ zlib/1.2.11
 bzip2/1.0.8
 doxygen/1.9.2
 m4/1.4.19
+bison/3.7.6
+flex/2.6.4
 
 [generators]
 cmake_paths

--- a/conanfile_ess.txt
+++ b/conanfile_ess.txt
@@ -3,10 +3,10 @@ boost/1.69.0
 hdf5/1.10.6
 zlib/1.2.11
 bzip2/1.0.8
-doxygen/1.9.2
-m4/1.4.19
-bison/3.7.6
-flex/2.6.4
+doxygen/1.9.1
+# m4/1.4.19
+# bison/3.7.6
+# flex/2.6.4
 
 [generators]
 cmake_paths

--- a/conanfile_macos.txt
+++ b/conanfile_macos.txt
@@ -1,0 +1,49 @@
+[requires]
+boost/1.69.0
+hdf5/1.10.6
+zlib/1.2.8
+bzip2/1.0.8
+
+[generators]
+cmake_paths
+cmake_find_package
+virtualbuildenv
+virtualrunenv
+
+[options]
+boost:shared=True
+boost:without_atomic=True
+boost:without_chrono=True
+boost:without_container=True
+boost:without_context=True
+boost:without_contract=True
+boost:without_coroutine=True
+boost:without_date_time=True
+boost:without_exception=True
+boost:without_fiber=True
+boost:without_graph=True
+boost:without_iostreams=True
+boost:without_locale=True
+boost:without_log=True
+boost:without_math=True
+boost:without_random=True
+boost:without_serialization=True
+boost:without_stacktrace=True
+boost:without_test=True
+boost:without_thread=True
+boost:without_timer=True
+boost:without_type_erasure=True
+boost:without_wave=True
+hdf5:shared=True
+hdf5:szip_support=with_libaec
+hdf5:szip_encoding=True
+hdf5:enable_cxx=False
+zip:shared=True
+
+[imports]
+bin, cmake -> ./bin
+bin, *.dll -> ./bin
+lib, *.dll -> ./bin
+lib, *.so.* -> ./lib
+lib, *.so -> ./lib
+share, * -> ./share

--- a/doc/source/api_reference/CMakeLists.txt
+++ b/doc/source/api_reference/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCES index.rst
             namespace_file.rst
             namespace_filter.rst
             namespace_node.rst
-            namespace_property.rst)
+            namespace_property.rst
+            namespace_error.rst)
 
 add_sphinx_source(${SOURCES})
 copy_to_current_build(${SOURCES})

--- a/doc/source/api_reference/index.rst
+++ b/doc/source/api_reference/index.rst
@@ -16,4 +16,5 @@ Follow this link to the Doxygen-generated `API reference <./doxygen/index.html>`
    namespace_filter
    namespace_node
    namespace_property
+   namespace_error
 

--- a/doc/source/api_reference/namespace_attribute.rst
+++ b/doc/source/api_reference/namespace_attribute.rst
@@ -2,14 +2,20 @@
 Namespace :cpp:any:`hdf5::attribute`
 ====================================
 
-:cpp:class:`Attribute`
-======================
+:cpp:class:`hdf5::attribute::Attribute`
+=======================================
 
 .. doxygenclass:: hdf5::attribute::Attribute
    :members:
    
-:cpp:class:`AttributeManager`
-=============================
+:cpp:class:`hdf5::attribute::AttributeManager`
+==============================================
 
 .. doxygenclass:: hdf5::attribute::AttributeManager
    :members:
+
+:cpp:class:`hdf5::attribute::AttributeIterator`
+===============================================
+
+.. doxygenclass:: hdf5::attribute::AttributeIterator
+   :members:      

--- a/doc/source/api_reference/namespace_attribute.rst
+++ b/doc/source/api_reference/namespace_attribute.rst
@@ -2,20 +2,20 @@
 Namespace :cpp:any:`hdf5::attribute`
 ====================================
 
-:cpp:class:`hdf5::attribute::Attribute`
-=======================================
+:cpp:class:`Attribute`
+======================
 
 .. doxygenclass:: hdf5::attribute::Attribute
    :members:
    
-:cpp:class:`hdf5::attribute::AttributeManager`
-==============================================
+:cpp:class:`AttributeManager`
+=============================
 
 .. doxygenclass:: hdf5::attribute::AttributeManager
    :members:
 
-:cpp:class:`hdf5::attribute::AttributeIterator`
-===============================================
+:cpp:class:`AttributeIterator`
+==============================
 
 .. doxygenclass:: hdf5::attribute::AttributeIterator
    :members:      

--- a/doc/source/api_reference/namespace_attribute.rst
+++ b/doc/source/api_reference/namespace_attribute.rst
@@ -2,20 +2,23 @@
 Namespace :cpp:any:`hdf5::attribute`
 ====================================
 
+Classes
+=======
+
 :cpp:class:`Attribute`
-======================
+----------------------
 
 .. doxygenclass:: hdf5::attribute::Attribute
    :members:
-   
+
 :cpp:class:`AttributeManager`
-=============================
+-----------------------------
 
 .. doxygenclass:: hdf5::attribute::AttributeManager
    :members:
 
 :cpp:class:`AttributeIterator`
-==============================
+------------------------------
 
 .. doxygenclass:: hdf5::attribute::AttributeIterator
-   :members:      
+   :members:

--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -5,19 +5,19 @@ Namespace :cpp:any:`hdf5::dataspace`
 Dataspace related classes and functions
 =======================================
 
-:cpp:class:`hdf5::dataspace::Dataspace`
+:cpp:class:`Dataspace`
 ---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Dataspace
    :members:
 
-:cpp:class:`hdf5::dataspace::Scalar`
+:cpp:class:`Scalar`
 ------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Scalar
    :members:
 
-:cpp:class:`hdf5::dataspace::Simple`
+:cpp:class:`Simple`
 ------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Simple
@@ -28,43 +28,43 @@ Dataspace related classes and functions
 Selection related classes and functions
 =======================================
 
-:cpp:class:`hdf5::dataspace::Selection`
+:cpp:class:`Selection`
 ---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Selection
    :members:
 
-:cpp:class:`hdf5::dataspace::Hyperslab`
+:cpp:class:`Hyperslab`
 ---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Hyperslab
    :members:
 
-:cpp:class:`hdf5::dataspace::Points`
+:cpp:class:`Points`
 ------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Points
    :members:
 
-:cpp:class:`hdf5::dataspace::SelectionManager`
+:cpp:class:`SelectionManager`
 ----------------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::SelectionManager
    :members:
 
-:cpp:class:`hdf5::dataspace::View`
+:cpp:class:`View`
 ----------------------------------
 
 .. doxygenclass:: hdf5::dataspace::View
    :members:
 
-:cpp:class:`hdf5::dataspace::DataspaceHolder`
+:cpp:class:`DataspaceHolder`
 ---------------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::DataspaceHolder
    :members:
 
-:cpp:class:`hdf5::dataspace::DataspacePool`
+:cpp:class:`DataspacePool`
 -------------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::DataspacePool
@@ -72,6 +72,9 @@ Selection related classes and functions
 
 Type traits
 ===========
+
+:cpp:class:`TypeTrait`
+----------------------
 
 .. doxygenclass:: hdf5::dataspace::TypeTrait
    :members:

--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -5,20 +5,20 @@ Namespace :cpp:any:`hdf5::dataspace`
 Dataspace related classes and functions
 =======================================
 
-:cpp:class:`Dataspace`
-----------------------
+:cpp:class:`hdf5::dataspace::Dataspace`
+---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Dataspace
    :members:
 
-:cpp:class:`Scalar`
--------------------
+:cpp:class:`hdf5::dataspace::Scalar`
+------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Scalar
    :members:
 
-:cpp:class:`Simple`
--------------------
+:cpp:class:`hdf5::dataspace::Simple`
+------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Simple
    :members:
@@ -28,38 +28,62 @@ Dataspace related classes and functions
 Selection related classes and functions
 =======================================
 
-:cpp:class:`Selection`
-----------------------
+:cpp:class:`hdf5::dataspace::Selection`
+---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Selection
    :members:
 
-:cpp:class:`Hyperslab`
-----------------------
+:cpp:class:`hdf5::dataspace::Hyperslab`
+---------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Hyperslab
    :members:
 
-:cpp:class:`Points`
--------------------
+:cpp:class:`hdf5::dataspace::Points`
+------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Points
+   :members:
+
+:cpp:class:`hdf5::dataspace::SelectionManager`
+----------------------------------------------
+
+.. doxygenclass:: hdf5::dataspace::SelectionManager
+   :members:
+
+:cpp:class:`hdf5::dataspace::View`
+----------------------------------
+
+.. doxygenclass:: hdf5::dataspace::View
+   :members:
+
+:cpp:class:`hdf5::dataspace::DataspaceHolder`
+---------------------------------------------
+
+.. doxygenclass:: hdf5::dataspace::DataspaceHolder
+   :members:
+
+:cpp:class:`hdf5::dataspace::DataspacePool`
+-------------------------------------------
+
+.. doxygenclass:: hdf5::dataspace::DataspacePool
    :members:
 
 Enumerations
 ============
 
-:cpp:enum:`Type`
-----------------
+:cpp:enum:`hdf5::dataspace::Type`
+---------------------------------
 
 .. doxygenenum:: hdf5::dataspace::Type
 
-:cpp:enum:`SelectionType`
--------------------------
+:cpp:enum:`hdf5::dataspace::SelectionType`
+------------------------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionType
 
-:cpp:enum:`SelectionOperation`
-------------------------------
+:cpp:enum:`hdf5::dataspace::SelectionOperation`
+-----------------------------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionOperation

--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -70,6 +70,12 @@ Selection related classes and functions
 .. doxygenclass:: hdf5::dataspace::DataspacePool
    :members:
 
+Type traits
+===========
+
+.. doxygenclass:: hdf5::dataspace::TypeTrait
+   :members:
+
 Enumerations
 ============
 

--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -28,17 +28,25 @@ Dataspace related classes and functions
 Selection related classes and functions
 =======================================
 
-:cpp:class:`Selection`
-----------------------
+:cpp:class:`Selection` and :cpp:type:`SelectionList`
+----------------------------------------------------
 
 .. doxygenclass:: hdf5::dataspace::Selection
    :members:
+
+.. doxygentypedef:: hdf5::dataspace::SelectionList
+
+.. doxygenfunction:: hdf5::dataspace::operator||(const Dataspace &, const SelectionList &)
+
 
 :cpp:class:`Hyperslab`
 ----------------------
 
 .. doxygenclass:: hdf5::dataspace::Hyperslab
    :members:
+
+.. doxygenfunction:: hdf5::dataspace::operator||(const Dataspace &, const Hyperslab &)
+		     
 
 :cpp:class:`Points`
 -------------------
@@ -87,12 +95,18 @@ Enumerations
 
 .. doxygenenum:: hdf5::dataspace::Type
 
+.. doxygenfunction:: hdf5::dataspace::operator<<(std::ostream &, const Type &)
+
 :cpp:enum:`SelectionType`
 -------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionType
 
+.. doxygenfunction:: hdf5::dataspace::operator<<(std::ostream &, const SelectionType &)
+
 :cpp:enum:`SelectionOperation`
 ------------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionOperation
+
+.. doxygenfunction:: hdf5::dataspace::operator<<(std::ostream &, const SelectionOperation &)

--- a/doc/source/api_reference/namespace_dataspace.rst
+++ b/doc/source/api_reference/namespace_dataspace.rst
@@ -6,19 +6,19 @@ Dataspace related classes and functions
 =======================================
 
 :cpp:class:`Dataspace`
----------------------------------------
+----------------------
 
 .. doxygenclass:: hdf5::dataspace::Dataspace
    :members:
 
 :cpp:class:`Scalar`
-------------------------------------
+-------------------
 
 .. doxygenclass:: hdf5::dataspace::Scalar
    :members:
 
 :cpp:class:`Simple`
-------------------------------------
+-------------------
 
 .. doxygenclass:: hdf5::dataspace::Simple
    :members:
@@ -29,43 +29,43 @@ Selection related classes and functions
 =======================================
 
 :cpp:class:`Selection`
----------------------------------------
+----------------------
 
 .. doxygenclass:: hdf5::dataspace::Selection
    :members:
 
 :cpp:class:`Hyperslab`
----------------------------------------
+----------------------
 
 .. doxygenclass:: hdf5::dataspace::Hyperslab
    :members:
 
 :cpp:class:`Points`
-------------------------------------
+-------------------
 
 .. doxygenclass:: hdf5::dataspace::Points
    :members:
 
 :cpp:class:`SelectionManager`
-----------------------------------------------
+-----------------------------
 
 .. doxygenclass:: hdf5::dataspace::SelectionManager
    :members:
 
 :cpp:class:`View`
-----------------------------------
+-----------------
 
 .. doxygenclass:: hdf5::dataspace::View
    :members:
 
 :cpp:class:`DataspaceHolder`
----------------------------------------------
+----------------------------
 
 .. doxygenclass:: hdf5::dataspace::DataspaceHolder
    :members:
 
 :cpp:class:`DataspacePool`
--------------------------------------------
+--------------------------
 
 .. doxygenclass:: hdf5::dataspace::DataspacePool
    :members:
@@ -82,17 +82,17 @@ Type traits
 Enumerations
 ============
 
-:cpp:enum:`hdf5::dataspace::Type`
----------------------------------
+:cpp:enum:`Type`
+----------------
 
 .. doxygenenum:: hdf5::dataspace::Type
 
-:cpp:enum:`hdf5::dataspace::SelectionType`
-------------------------------------------
+:cpp:enum:`SelectionType`
+-------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionType
 
-:cpp:enum:`hdf5::dataspace::SelectionOperation`
------------------------------------------------
+:cpp:enum:`SelectionOperation`
+------------------------------
 
 .. doxygenenum:: hdf5::dataspace::SelectionOperation

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -11,6 +11,10 @@ Classes
 .. doxygenclass:: hdf5::datatype::Datatype
    :members:
 
+.. doxygenfunction:: hdf5::datatype::operator==(const Datatype &, const Datatype &)
+
+.. doxygenfunction:: hdf5::datatype::operator!=(const Datatype &, const Datatype &)
+
 :cpp:class:`Array`
 ------------------
 

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -62,11 +62,13 @@ Type traits
 Enumerations
 ============
 
-:cpp:enum:`Class`
+:cpp:enum:`EBool`
 -----------------
 
-.. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Class &)
+.. doxygenenum:: hdf5::datatype::EBool
 
+.. doxygenfunction:: hdf5::datatype::is_bool(const Enum &);
+                 
 :cpp:enum:`Order`
 -----------------
 
@@ -119,3 +121,6 @@ Enumerations
 -----------------
 
 .. doxygenenum:: hdf5::datatype::Class
+
+.. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Class &)
+

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -5,62 +5,62 @@ Namespace :cpp:any:`hdf5::datatype`
 Classes
 =======
 
-:cpp:class:`hdf5::datatype::Datatype`
--------------------------------------
+:cpp:class:`Datatype`
+---------------------
 
 .. doxygenclass:: hdf5::datatype::Datatype
    :members:
 
-:cpp:class:`hdf5::datatype::Array`
-----------------------------------
+:cpp:class:`Array`
+------------------
 
 .. doxygenclass:: hdf5::datatype::Array
    :members:
 
-:cpp:class:`hdf5::datatype::VLengthArray`
------------------------------------------
+:cpp:class:`VLengthArray`
+-------------------------
 
 .. doxygenclass:: hdf5::datatype::VLengthArray
    :members:
 
-:cpp:class:`hdf5::datatype::Compound`
--------------------------------------
+:cpp:class:`Compound`
+---------------------
 
 .. doxygenclass:: hdf5::datatype::Compound
    :members:
 
-:cpp:class:`hdf5::datatype::String`
------------------------------------
+:cpp:class:`String`
+-------------------
 
 .. doxygenclass:: hdf5::datatype::String
    :members:
 
-:cpp:class:`hdf5::datatype::Enum`
----------------------------------
+:cpp:class:`Enum`
+-----------------
 
 .. doxygenclass:: hdf5::datatype::Enum
    :members:
 
-:cpp:class:`hdf5::datatype::Integer`
-------------------------------------
+:cpp:class:`Integer`
+--------------------
 
 .. doxygenclass:: hdf5::datatype::Integer
    :members:
 
-:cpp:class:`hdf5::datatype::Float`
-----------------------------------
+:cpp:class:`Float`
+------------------
 
 .. doxygenclass:: hdf5::datatype::Float
    :members:
 
-:cpp:class:`hdf5::datatype::float16_t`
---------------------------------------
+:cpp:class:`float16_t`
+----------------------
 
 .. doxygenclass:: hdf5::datatype::float16_t
    :members:
 
-:cpp:class:`hdf5::datatype::DatatypeHolder`
--------------------------------------------
+:cpp:class:`DatatypeHolder`
+---------------------------
 
 .. doxygenclass:: hdf5::datatype::DatatypeHolder
    :members:
@@ -68,48 +68,52 @@ Classes
 Type traits
 ===========
 
+:cpp:class:`TypeTrait`
+----------------------
+
 .. doxygenclass:: hdf5::datatype::TypeTrait
    :members:
 
 Enumerations
 ============
 
-:cpp:enum:`hdf5::datatype::EBool`
----------------------------------
+:cpp:enum:`EBool`
+-----------------
 
 .. doxygenenum:: hdf5::datatype::EBool
 
 .. doxygenfunction:: hdf5::datatype::is_bool(const Enum &);
 
-:cpp:enum:`hdf5::datatype::Order`
----------------------------------
+:cpp:enum:`Order`
+-----------------
 
 .. doxygenenum:: hdf5::datatype::Order
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Order &)
 
-:cpp:enum:`hdf5::datatype::Sign`
---------------------------------
+:cpp:enum:`Sign`
+----------------
 
 .. doxygenenum:: hdf5::datatype::Sign
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Sign &)
 
-:cpp:enum:`hdf5::datatype::Norm`
---------------------------------
+:cpp:enum:`Norm`
+----------------
 
 .. doxygenenum:: hdf5::datatype::Norm
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Norm &)
 
-:cpp:enum:`hdf5::datatype::Pad`
--------------------------------
+:cpp:enum:`Pad`
+---------------
+
 .. doxygenenum:: hdf5::datatype::Pad
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Pad &)
 
-:cpp:enum:`hdf5::datatype::StringPad`
--------------------------------------
+:cpp:enum:`StringPad`
+---------------------
 
 .. doxygenenum:: hdf5::datatype::StringPad
 

--- a/doc/source/api_reference/namespace_datatype.rst
+++ b/doc/source/api_reference/namespace_datatype.rst
@@ -5,52 +5,64 @@ Namespace :cpp:any:`hdf5::datatype`
 Classes
 =======
 
-:cpp:class:`Datatype`
----------------------
+:cpp:class:`hdf5::datatype::Datatype`
+-------------------------------------
 
 .. doxygenclass:: hdf5::datatype::Datatype
    :members:
 
-:cpp:class:`Array`
-------------------
+:cpp:class:`hdf5::datatype::Array`
+----------------------------------
 
 .. doxygenclass:: hdf5::datatype::Array
    :members:
 
-:cpp:class:`VLengthArray`
--------------------------
+:cpp:class:`hdf5::datatype::VLengthArray`
+-----------------------------------------
 
 .. doxygenclass:: hdf5::datatype::VLengthArray
    :members:
 
-:cpp:class:`Compound`
----------------------
+:cpp:class:`hdf5::datatype::Compound`
+-------------------------------------
 
 .. doxygenclass:: hdf5::datatype::Compound
    :members:
 
-:cpp:class:`Float`
-------------------
-
-.. doxygenclass:: hdf5::datatype::Float
-   :members:
-
-:cpp:class:`Integer`
---------------------
-
-.. doxygenclass:: hdf5::datatype::Integer
-   :members:
-
-:cpp:class:`String`
--------------------
+:cpp:class:`hdf5::datatype::String`
+-----------------------------------
 
 .. doxygenclass:: hdf5::datatype::String
    :members:
 
-:cpp:class:`Enum`
------------------
+:cpp:class:`hdf5::datatype::Enum`
+---------------------------------
 
 .. doxygenclass:: hdf5::datatype::Enum
+   :members:
+
+:cpp:class:`hdf5::datatype::Integer`
+------------------------------------
+
+.. doxygenclass:: hdf5::datatype::Integer
+   :members:
+
+:cpp:class:`hdf5::datatype::Float`
+----------------------------------
+
+.. doxygenclass:: hdf5::datatype::Float
+   :members:
+
+:cpp:class:`hdf5::datatype::float16_t`
+--------------------------------------
+
+.. doxygenclass:: hdf5::datatype::float16_t
+   :members:
+
+:cpp:class:`hdf5::datatype::DatatypeHolder`
+-------------------------------------------
+
+.. doxygenclass:: hdf5::datatype::DatatypeHolder
    :members:
 
 Type traits
@@ -62,42 +74,42 @@ Type traits
 Enumerations
 ============
 
-:cpp:enum:`EBool`
------------------
+:cpp:enum:`hdf5::datatype::EBool`
+---------------------------------
 
 .. doxygenenum:: hdf5::datatype::EBool
 
 .. doxygenfunction:: hdf5::datatype::is_bool(const Enum &);
-                 
-:cpp:enum:`Order`
------------------
+
+:cpp:enum:`hdf5::datatype::Order`
+---------------------------------
 
 .. doxygenenum:: hdf5::datatype::Order
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Order &)
 
-:cpp:enum:`Sign`
-----------------
+:cpp:enum:`hdf5::datatype::Sign`
+--------------------------------
 
 .. doxygenenum:: hdf5::datatype::Sign
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Sign &)
 
-:cpp:enum:`Norm`
-----------------
+:cpp:enum:`hdf5::datatype::Norm`
+--------------------------------
 
 .. doxygenenum:: hdf5::datatype::Norm
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Norm &)
 
-:cpp:enum:`Pad`
----------------
+:cpp:enum:`hdf5::datatype::Pad`
+-------------------------------
 .. doxygenenum:: hdf5::datatype::Pad
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Pad &)
 
-:cpp:enum:`StringPad`
----------------------
+:cpp:enum:`hdf5::datatype::StringPad`
+-------------------------------------
 
 .. doxygenenum:: hdf5::datatype::StringPad
 
@@ -123,4 +135,3 @@ Enumerations
 .. doxygenenum:: hdf5::datatype::Class
 
 .. doxygenfunction:: hdf5::datatype::operator<<(std::ostream &, const Class &)
-

--- a/doc/source/api_reference/namespace_error.rst
+++ b/doc/source/api_reference/namespace_error.rst
@@ -1,0 +1,34 @@
+================================
+Namespace :cpp:any:`hdf5::error`
+================================
+
+Classes
+=======
+
+:cpp:class:`Singleton`
+----------------------
+
+.. doxygenclass:: hdf5::error::Singleton
+   :members:
+
+:cpp:class:`H5CError`
+---------------------
+
+.. doxygenclass:: hdf5::error::H5CError
+   :members:
+
+:cpp:class:`Descriptor`
+-----------------------
+
+.. doxygenstruct:: hdf5::error::Descriptor
+   :members:
+
+.. doxygenfunction:: hdf5::error::operator<<(std::ostream &, const Descriptor &)
+
+Functions
+=========
+
+:cpp:func:`print_nested`
+------------------------
+
+.. doxygenfunction:: hdf5::error::print_nested(const std::exception&, int)

--- a/doc/source/api_reference/namespace_file.rst
+++ b/doc/source/api_reference/namespace_file.rst
@@ -2,10 +2,6 @@
 Namespace :cpp:any:`hdf5::file`
 ===============================
 
-Enumerations
-============
-
-
 The :cpp:class:`File` class
 ===========================
 
@@ -13,30 +9,96 @@ The :cpp:class:`File` class
    :members:
    
 Functions
----------
+=========
+
+:cpp:func:`create`
+------------------
 
 .. doxygenfunction:: hdf5::file::create(const fs::path &, AccessFlags, const property::FileCreationList &, const property::FileAccessList &)
 
+:cpp:func:`open`
+----------------
+
 .. doxygenfunction:: hdf5::file::open(const fs::path &, AccessFlags, const property::FileAccessList &)
+
+:cpp:func:`is_hdf5_file`
+------------------------
 
 .. doxygenfunction:: hdf5::file::is_hdf5_file
 
-Flags
------
+Enumerations
+============
+
+:cpp:class:`AccessFlags` and :cpp:type:`AccessFlagsBase`
+--------------------------------------------------------
 
 .. doxygenenum:: hdf5::file::AccessFlags
 
+.. doxygentypedef:: hdf5::file::AccessFlagsBase
+
 .. doxygenfunction:: hdf5::file::operator|(const AccessFlags &, const AccessFlags &)
+
+.. doxygenfunction:: hdf5::file::operator|(const AccessFlagsBase &, const AccessFlags &)
+
+.. doxygenfunction:: hdf5::file::operator|(const AccessFlags &, const AccessFlagsBase &)
+
+.. doxygenfunction:: hdf5::file::operator&(const AccessFlags &, const AccessFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const AccessFlagsBase &, const AccessFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const AccessFlags &, const AccessFlagsBase &)
 
 .. doxygenfunction:: hdf5::file::operator<<(std::ostream &, const AccessFlags &)
 
+:cpp:class:`SearchFlags` and :cpp:type:`SearchFlagsBase`
+--------------------------------------------------------
+
 .. doxygenenum:: hdf5::file::SearchFlags
+
+.. doxygentypedef:: hdf5::file::SearchFlagsBase
 
 .. doxygenfunction:: hdf5::file::operator|(const SearchFlags &, const SearchFlags &)
 
+.. doxygenfunction:: hdf5::file::operator|(const SearchFlagsBase &, const SearchFlags &)
+
+.. doxygenfunction:: hdf5::file::operator|(const SearchFlags &, const SearchFlagsBase &)
+
+.. doxygenfunction:: hdf5::file::operator&(const SearchFlags &, const SearchFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const SearchFlagsBase &, const SearchFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const SearchFlags &, const SearchFlagsBase &)
+
 .. doxygenfunction:: hdf5::file::operator<<(std::ostream &, const SearchFlags &)
 
+:cpp:class:`ImageFlags` and :cpp:type:`ImageFlagsBase`
+------------------------------------------------------
+
+.. doxygenenum:: hdf5::file::ImageFlags
+
+.. doxygentypedef:: hdf5::file::ImageFlagsBase
+
+.. doxygenfunction:: hdf5::file::operator|(const ImageFlags &, const ImageFlags &)
+
+.. doxygenfunction:: hdf5::file::operator|(const ImageFlagsBase &, const ImageFlags &)
+
+.. doxygenfunction:: hdf5::file::operator|(const ImageFlags &, const ImageFlagsBase &)
+
+.. doxygenfunction:: hdf5::file::operator&(const ImageFlags &, const ImageFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const ImageFlagsBase &, const ImageFlags &)
+
+.. doxygenfunction:: hdf5::file::operator&(const ImageFlags &, const ImageFlagsBase &)
+
+.. doxygenfunction:: hdf5::file::operator<<(std::ostream &, const ImageFlags &)
+
+
+:cpp:class:`Scope` and :cpp:type:`ScopeBase`
+--------------------------------------------
+
 .. doxygenenum:: hdf5::file::Scope
+
+.. doxygentypedef:: hdf5::file::ScopeBase
 
 .. doxygenfunction:: hdf5::file::operator<<(std::ostream &, const Scope &)
 

--- a/doc/source/api_reference/namespace_file.rst
+++ b/doc/source/api_reference/namespace_file.rst
@@ -6,8 +6,8 @@ Enumerations
 ============
 
 
-The :cpp:class:`hdf5::file::File` class
-=======================================
+The :cpp:class:`File` class
+===========================
 
 .. doxygenclass:: hdf5::file::File
    :members:
@@ -45,35 +45,35 @@ Flags
 Driver classes
 ==============
 
-:cpp:class:`hdf5::file::Driver`
--------------------------------
+:cpp:class:`Driver`
+-------------------
 
 .. doxygenclass:: hdf5::file::Driver
    :members:
    
 .. doxygenenum:: hdf5::file::DriverID
    
-:cpp:class:`hdf5::file::PosixDriver`
-------------------------------------
+:cpp:class:`PosixDriver`
+------------------------
 
 .. doxygenclass:: hdf5::file::PosixDriver
    :members:
 
 
-:cpp:class:`hdf5::file::MemoryDriver`
--------------------------------------
+:cpp:class:`MemoryDriver`
+-------------------------
    
 .. doxygenclass:: hdf5::file::MemoryDriver
    :members:
 
-:cpp:class:`hdf5::file::DirectDriver`
--------------------------------------
+:cpp:class:`DirectDriver`
+-------------------------
 
 .. doxygenclass:: hdf5::file::DirectDriver
    :members:
 
-:cpp:class:`hdf5::file::MPIDriver`
-----------------------------------
+:cpp:class:`MPIDriver`
+----------------------
 
 .. doxygenclass:: hdf5::file::MPIDriver
    :members:

--- a/doc/source/api_reference/namespace_file.rst
+++ b/doc/source/api_reference/namespace_file.rst
@@ -6,8 +6,8 @@ Enumerations
 ============
 
 
-The :cpp:class:`File` class
-===========================
+The :cpp:class:`hdf5::file::File` class
+=======================================
 
 .. doxygenclass:: hdf5::file::File
    :members:
@@ -45,35 +45,35 @@ Flags
 Driver classes
 ==============
 
-:cpp:class:`Driver`
--------------------
+:cpp:class:`hdf5::file::Driver`
+-------------------------------
 
 .. doxygenclass:: hdf5::file::Driver
    :members:
    
 .. doxygenenum:: hdf5::file::DriverID
    
-:cpp:class:`PosixDriver`
-------------------------
+:cpp:class:`hdf5::file::PosixDriver`
+------------------------------------
 
 .. doxygenclass:: hdf5::file::PosixDriver
    :members:
 
 
-:cpp:class:`MemoryDriver`
--------------------------
+:cpp:class:`hdf5::file::MemoryDriver`
+-------------------------------------
    
 .. doxygenclass:: hdf5::file::MemoryDriver
    :members:
 
-:cpp:class:`DirectDriver`
--------------------------
+:cpp:class:`hdf5::file::DirectDriver`
+-------------------------------------
 
 .. doxygenclass:: hdf5::file::DirectDriver
    :members:
 
-:cpp:class:`MPIDriver`
-----------------------
+:cpp:class:`hdf5::file::MPIDriver`
+----------------------------------
 
 .. doxygenclass:: hdf5::file::MPIDriver
    :members:

--- a/doc/source/api_reference/namespace_filter.rst
+++ b/doc/source/api_reference/namespace_filter.rst
@@ -2,63 +2,82 @@
 Namespace :cpp:any:`hdf5::filter`
 =================================
 
-Enumerations
-============
-
-.. doxygenenum:: hdf5::filter::Availability
+Classes
+=======
 
 :cpp:class:`Filter`
-===================
+-------------------
 
 .. doxygenclass:: hdf5::filter::Filter
    :members:
 
+:cpp:class:`ExternalFilter`
+---------------------------
+
+.. doxygenclass:: hdf5::filter::ExternalFilter
+   :members:
+
+:cpp:class:`ExternalFilters`
+----------------------------
+
+.. doxygenclass:: hdf5::filter::ExternalFilters
+   :members:
+
+Functions
+=========
+
+:cpp:func:`is_filter_available`
+-------------------------------
+
+.. doxygenfunction:: hdf5::filter::is_filter_available(FilterID)
+
+Enumerations
+============
+
+:cpp:enum:`Availability`
+------------------------
+
+.. doxygenenum:: hdf5::filter::Availability
+
+Filter classes
+==============
+
 :cpp:class:`Deflate`
-====================
+--------------------
 
 .. doxygenclass:: hdf5::filter::Deflate
    :members:
 
 :cpp:class:`Shuffle`
-====================
+--------------------
 
 .. doxygenclass:: hdf5::filter::Shuffle
    :members:
 
 :cpp:class:`Fletcher32`
-=======================
+-----------------------
 
 .. doxygenclass:: hdf5::filter::Fletcher32
    :members:
 
 :cpp:class:`SZip`
-=================
+-----------------
 
 .. doxygenclass:: hdf5::filter::SZip
    :members:
 
 :cpp:class:`NBit`
-===================
+-----------------
 
 .. doxygenclass:: hdf5::filter::NBit
    :members:
 
 :cpp:class:`ScaleOffset`
-========================
+------------------------
 
 .. doxygenclass:: hdf5::filter::ScaleOffset
    :members:
 
 .. doxygenenum:: hdf5::filter::SOScaleType
 
-:cpp:class:`ExternalFilter`
-===========================
-
-.. doxygenclass:: hdf5::filter::ExternalFilter
-   :members:
-
-:cpp:class:`ExternalFilters`
-============================
-
-.. doxygenclass:: hdf5::filter::ExternalFilters
-   :members:
+.. doxygenfunction:: hdf5::filter::operator<<(std::ostream &stream, const SOScaleType &scale_type)

--- a/doc/source/api_reference/namespace_filter.rst
+++ b/doc/source/api_reference/namespace_filter.rst
@@ -7,58 +7,58 @@ Enumerations
 
 .. doxygenenum:: hdf5::filter::Availability
 
-:cpp:class:`hdf5::filter::Filter`
-=================================
+:cpp:class:`Filter`
+===================
 
 .. doxygenclass:: hdf5::filter::Filter
    :members:
 
-:cpp:class:`hdf5::filter::Deflate`
-==================================
+:cpp:class:`Deflate`
+====================
 
 .. doxygenclass:: hdf5::filter::Deflate
    :members:
 
-:cpp:class:`hdf5::filter::Shuffle`
-==================================
+:cpp:class:`Shuffle`
+====================
 
 .. doxygenclass:: hdf5::filter::Shuffle
    :members:
 
-:cpp:class:`hdf5::filter::Fletcher32`
-=====================================
+:cpp:class:`Fletcher32`
+=======================
 
 .. doxygenclass:: hdf5::filter::Fletcher32
    :members:
 
-:cpp:class:`hdf5::filter::SZip`
-===============================
+:cpp:class:`SZip`
+=================
 
 .. doxygenclass:: hdf5::filter::SZip
    :members:
 
-:cpp:class:``
-=================================
+:cpp:class:`NBit`
+===================
 
 .. doxygenclass:: hdf5::filter::NBit
    :members:
 
-:cpp:class:`hdf5::filter::ScaleOffset`
-======================================
+:cpp:class:`ScaleOffset`
+========================
 
 .. doxygenclass:: hdf5::filter::ScaleOffset
    :members:
 
 .. doxygenenum:: hdf5::filter::SOScaleType
 
-:cpp:class:`hdf5::filter::ExternalFilter`
-=========================================
+:cpp:class:`ExternalFilter`
+===========================
 
 .. doxygenclass:: hdf5::filter::ExternalFilter
    :members:
 
-:cpp:class:`hdf5::filter::ExternalFilters`
-==========================================
+:cpp:class:`ExternalFilters`
+============================
 
 .. doxygenclass:: hdf5::filter::ExternalFilters
    :members:

--- a/doc/source/api_reference/namespace_filter.rst
+++ b/doc/source/api_reference/namespace_filter.rst
@@ -2,28 +2,63 @@
 Namespace :cpp:any:`hdf5::filter`
 =================================
 
+Enumerations
+============
+
 .. doxygenenum:: hdf5::filter::Availability
+
+:cpp:class:`hdf5::filter::Filter`
+=================================
 
 .. doxygenclass:: hdf5::filter::Filter
    :members:
 
+:cpp:class:`hdf5::filter::Deflate`
+==================================
+
 .. doxygenclass:: hdf5::filter::Deflate
    :members:
+
+:cpp:class:`hdf5::filter::Shuffle`
+==================================
 
 .. doxygenclass:: hdf5::filter::Shuffle
    :members:
 
+:cpp:class:`hdf5::filter::Fletcher32`
+=====================================
+
 .. doxygenclass:: hdf5::filter::Fletcher32
    :members:
+
+:cpp:class:`hdf5::filter::SZip`
+===============================
 
 .. doxygenclass:: hdf5::filter::SZip
    :members:
 
+:cpp:class:``
+=================================
+
 .. doxygenclass:: hdf5::filter::NBit
    :members:
+
+:cpp:class:`hdf5::filter::ScaleOffset`
+======================================
 
 .. doxygenclass:: hdf5::filter::ScaleOffset
    :members:
 
+.. doxygenenum:: hdf5::filter::SOScaleType
+
+:cpp:class:`hdf5::filter::ExternalFilter`
+=========================================
+
 .. doxygenclass:: hdf5::filter::ExternalFilter
+   :members:
+
+:cpp:class:`hdf5::filter::ExternalFilters`
+==========================================
+
+.. doxygenclass:: hdf5::filter::ExternalFilters
    :members:

--- a/doc/source/api_reference/namespace_hdf5.rst
+++ b/doc/source/api_reference/namespace_hdf5.rst
@@ -25,6 +25,10 @@ Namespace :cpp:any:`hdf5`
 .. doxygenclass:: hdf5::ObjectHandle
    :members:
 
+.. doxygenenum:: hdf5::ObjectHandle::Policy
+
+.. doxygenenum:: hdf5::ObjectHandle::Type
+
 :cpp:class:`hdf5::Version`
 ==========================
    
@@ -36,4 +40,40 @@ Namespace :cpp:any:`hdf5`
    
 .. doxygenclass:: hdf5::ObjectId
    :members:
+
+:cpp:class:`hdf5::Context`
+==========================
    
+.. doxygenclass:: hdf5::Context
+   :members:
+
+:cpp:class:`hdf5::IOWriteBuffer`
+================================
+   
+.. doxygenclass:: hdf5::IOWriteBuffer
+   :members:
+   
+:cpp:class:`hdf5::IOReadBuffer`
+===============================
+   
+.. doxygenclass:: hdf5::IOReadBuffer
+   :members:
+
+:cpp:class:`hdf5::FixedLengthStringBuffer`
+==========================================
+   
+.. doxygenclass:: hdf5::FixedLengthStringBuffer
+   :members:
+
+:cpp:class:`hdf5::Iterator`
+===========================
+   
+.. doxygenclass:: hdf5::Iterator
+   :members:
+
+:cpp:class:`hdf5::ArrayAdapter`
+===============================
+   
+.. doxygenclass:: hdf5::ArrayAdapter
+   :members:
+

--- a/doc/source/api_reference/namespace_hdf5.rst
+++ b/doc/source/api_reference/namespace_hdf5.rst
@@ -2,26 +2,12 @@
 Namespace :cpp:any:`hdf5`
 =========================
 
-:cpp:class:`Path`
-=================
-
-.. doxygenclass:: hdf5::Path
-   :members:
-   
-:cpp:class:`IteratorConfig`
-===========================
-
-.. doxygenclass:: hdf5::IteratorConfig
-   :members:
-   
-   
-.. doxygenenum:: hdf5::IterationOrder
-
-.. doxygenenum:: hdf5::IterationIndex
+Classes
+=======
 
 :cpp:class:`ObjectHandle`
-=========================
-   
+-------------------------
+
 .. doxygenclass:: hdf5::ObjectHandle
    :members:
 
@@ -29,51 +15,119 @@ Namespace :cpp:any:`hdf5`
 
 .. doxygenenum:: hdf5::ObjectHandle::Type
 
+.. doxygenfunction:: hdf5::operator==(const ObjectHandle &,const ObjectHandle &)
+
+.. doxygenfunction:: hdf5::operator!=(const ObjectHandle &,const ObjectHandle &)
+
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const ObjectHandle::Type &)
+
+:cpp:class:`Path`
+-----------------
+
+.. doxygenclass:: hdf5::Path
+   :members:
+
+.. doxygenfunction:: hdf5::operator+(const Path &,const Path &)
+
+.. doxygenfunction:: hdf5::operator==(const Path &,const Path &)
+
+.. doxygenfunction:: hdf5::operator!=(const Path &,const Path &)
+
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const Path &)
+
+.. doxygenfunction:: hdf5::common_base(const Path&, const Path&)
+
+:cpp:class:`IteratorConfig`
+---------------------------
+
+.. doxygenclass:: hdf5::IteratorConfig
+   :members:
+
+
+.. doxygenenum:: hdf5::IterationOrder
+
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const IterationOrder &)
+
+.. doxygenenum:: hdf5::IterationIndex
+
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const IterationIndex &)
+
 :cpp:class:`Version`
-====================
-   
+--------------------
+
 .. doxygenclass:: hdf5::Version
    :members:
 
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const Version &)
+
+.. doxygenfunction:: hdf5::operator==(const Version &,const Version &)
+
+.. doxygenfunction:: hdf5::operator!=(const Version &,const Version &)
+
+.. doxygenfunction:: hdf5::operator<=(const Version &,const Version &)
+
+.. doxygenfunction:: hdf5::operator>=(const Version &,const Version &)
+
+.. doxygenfunction:: hdf5::operator<(const Version &,const Version &)
+
+.. doxygenfunction:: hdf5::operator>(const Version &,const Version &)
+
 :cpp:class:`ObjectId`
-=====================
-   
+---------------------
+
 .. doxygenclass:: hdf5::ObjectId
    :members:
 
+.. doxygenfunction:: hdf5::operator<<(std::ostream &, const ObjectId &)
+
 :cpp:class:`Context`
-====================
-   
+--------------------
+
 .. doxygenclass:: hdf5::Context
    :members:
 
 :cpp:class:`IOWriteBuffer`
-==========================
-   
+--------------------------
+
 .. doxygenclass:: hdf5::IOWriteBuffer
    :members:
-   
+
 :cpp:class:`IOReadBuffer`
-=========================
-   
+-------------------------
+
 .. doxygenclass:: hdf5::IOReadBuffer
    :members:
 
 :cpp:class:`FixedLengthStringBuffer`
-====================================
-   
+------------------------------------
+
 .. doxygenclass:: hdf5::FixedLengthStringBuffer
    :members:
 
 :cpp:class:`Iterator`
-=====================
-   
+---------------------
+
 .. doxygenclass:: hdf5::Iterator
    :members:
 
+.. doxygenfunction:: hdf5::operator+(const Iterator&, ssize_t)
+
+.. doxygenfunction:: hdf5::operator+(ssize_t, const Iterator&)
+
+.. doxygenfunction:: hdf5::operator-(const Iterator&, ssize_t)
+
+.. doxygenfunction:: hdf5::operator-(const Iterator&, const Iterator&)
+
 :cpp:class:`ArrayAdapter`
-=========================
-   
+-------------------------
+
 .. doxygenclass:: hdf5::ArrayAdapter
    :members:
 
+Functions
+=========
+
+:cpp:func:`current_library_version`
+-----------------------------------
+
+.. doxygenfunction:: hdf5::current_library_version

--- a/doc/source/api_reference/namespace_hdf5.rst
+++ b/doc/source/api_reference/namespace_hdf5.rst
@@ -2,14 +2,14 @@
 Namespace :cpp:any:`hdf5`
 =========================
 
-:cpp:class:`hdf5::Path`
-=======================
+:cpp:class:`Path`
+=================
 
 .. doxygenclass:: hdf5::Path
    :members:
    
-:cpp:class:`hdf5::IteratorConfig`
-=================================
+:cpp:class:`IteratorConfig`
+===========================
 
 .. doxygenclass:: hdf5::IteratorConfig
    :members:
@@ -19,8 +19,8 @@ Namespace :cpp:any:`hdf5`
 
 .. doxygenenum:: hdf5::IterationIndex
 
-:cpp:class:`hdf5::ObjectHandle`
-===============================
+:cpp:class:`ObjectHandle`
+=========================
    
 .. doxygenclass:: hdf5::ObjectHandle
    :members:
@@ -29,50 +29,50 @@ Namespace :cpp:any:`hdf5`
 
 .. doxygenenum:: hdf5::ObjectHandle::Type
 
-:cpp:class:`hdf5::Version`
-==========================
+:cpp:class:`Version`
+====================
    
 .. doxygenclass:: hdf5::Version
    :members:
 
-:cpp:class:`hdf5::ObjectId`
-===========================
+:cpp:class:`ObjectId`
+=====================
    
 .. doxygenclass:: hdf5::ObjectId
    :members:
 
-:cpp:class:`hdf5::Context`
-==========================
+:cpp:class:`Context`
+====================
    
 .. doxygenclass:: hdf5::Context
    :members:
 
-:cpp:class:`hdf5::IOWriteBuffer`
-================================
+:cpp:class:`IOWriteBuffer`
+==========================
    
 .. doxygenclass:: hdf5::IOWriteBuffer
    :members:
    
-:cpp:class:`hdf5::IOReadBuffer`
-===============================
+:cpp:class:`IOReadBuffer`
+=========================
    
 .. doxygenclass:: hdf5::IOReadBuffer
    :members:
 
-:cpp:class:`hdf5::FixedLengthStringBuffer`
-==========================================
+:cpp:class:`FixedLengthStringBuffer`
+====================================
    
 .. doxygenclass:: hdf5::FixedLengthStringBuffer
    :members:
 
-:cpp:class:`hdf5::Iterator`
-===========================
+:cpp:class:`Iterator`
+=====================
    
 .. doxygenclass:: hdf5::Iterator
    :members:
 
-:cpp:class:`hdf5::ArrayAdapter`
-===============================
+:cpp:class:`ArrayAdapter`
+=========================
    
 .. doxygenclass:: hdf5::ArrayAdapter
    :members:

--- a/doc/source/api_reference/namespace_node.rst
+++ b/doc/source/api_reference/namespace_node.rst
@@ -5,8 +5,8 @@ Namespace :cpp:any:`hdf5::node`
 Classes
 =======
 
-:cpp:class:`Node`
------------------
+:cpp:class:`hdf5::node::Node`
+-----------------------------
 
 .. doxygenclass:: hdf5::node::Node
    :members:
@@ -15,8 +15,8 @@ Classes
 
 .. doxygenfunction:: hdf5::node::operator!=(const Node &, const Node &)
 
-:cpp:class:`Link`
------------------
+:cpp:class:`hdf5::node::Link`
+-----------------------------
 
 .. doxygenclass:: hdf5::node::Link
    :members:
@@ -25,26 +25,26 @@ Classes
 
 .. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const Link &)
 
-:cpp:class:`LinkTarget`
------------------------
+:cpp:class:`hdf5::node::LinkTarget`
+-----------------------------------
 
 .. doxygenclass:: hdf5::node::LinkTarget
    :members:
 
-:cpp:class:`Group`
-------------------
+:cpp:class:`hdf5::node::Group`
+------------------------------
 
 .. doxygenclass:: hdf5::node::Group
    :members:
 
-:cpp:class:`GroupView`
-----------------------
+:cpp:class:`hdf5::node::GroupView`
+----------------------------------
 
 .. doxygenclass:: hdf5::node::GroupView
    :members:
 
-:cpp:class:`NodeView`
----------------------
+:cpp:class:`hdf5::node::NodeView`
+---------------------------------
 
 .. doxygenclass:: hdf5::node::NodeView
    :members:
@@ -55,8 +55,8 @@ Classes
 .. doxygenclass:: hdf5::node::RecursiveNodeIterator
    :members:
 
-:cpp:class:`LinkView`
----------------------
+:cpp:class:`hdf5::node::LinkView`
+---------------------------------
 
 .. doxygenclass:: hdf5::node::LinkView
    :members:
@@ -67,22 +67,22 @@ Classes
 .. doxygenclass:: hdf5::node::RecursiveLinkIterator
    :members:
 
-:cpp:class:`Dataset`
---------------------
+:cpp:class:`hdf5::node::Dataset`
+--------------------------------
 
 .. doxygenclass:: hdf5::node::Dataset
    :members:
 
 
-:cpp:class:`ChunkedDataset`
----------------------------
+:cpp:class:`hdf5::node::ChunkedDataset`
+---------------------------------------
 
 .. doxygenclass:: hdf5::node::ChunkedDataset
    :members:
 
 
-:cpp:class:`VirtualDataset`
----------------------------
+:cpp:class:`hdf5::node::VirtualDataset`
+---------------------------------------
 
 .. doxygenclass:: hdf5::node::VirtualDataset
    :members:
@@ -90,27 +90,27 @@ Classes
 Functions
 =========
 
-:cpp:func:`copy`
-----------------
+:cpp:func:`hdf5::node::copy`
+----------------------------
 
 .. doxygenfunction:: hdf5::node::copy(const Node &, const Group &, const property::ObjectCopyList &, const property::LinkCreationList &)
 
-:cpp:func:`move`
-----------------
+:cpp:func:`hdf5::node::move`
+----------------------------
 
 .. doxygenfunction:: hdf5::node::move(const Node &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
 .. doxygenfunction:: hdf5::node::move(const Node &, const Group &, const property::LinkCreationList &, const property::LinkAccessList &)
 
-:cpp:func:`remove`
-------------------
+:cpp:func:`hdf5::node::remove`
+------------------------------
 
 .. doxygenfunction:: hdf5::node::remove(const Node &, const property::LinkAccessList &)
 
 .. doxygenfunction:: hdf5::node::remove(const Group &, const Path &, const property::LinkAccessList &)
 
-:cpp:func:`link`
-----------------
+:cpp:func:`hdf5::node::link`
+----------------------------
 
 .. doxygenfunction:: hdf5::node::link(const Node &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
@@ -119,33 +119,33 @@ Functions
 .. doxygenfunction:: hdf5::node::link(const fs::path &, const Path &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
 
-:cpp:func:`get_node`
---------------------
+:cpp:func:`hdf5::node::get_node`
+--------------------------------
 
 .. doxygenfunction:: hdf5::node::get_node
 
-:cpp:func:`get_real_base`
--------------------------
+:cpp:func:`hdf5::node::get_real_base`
+-------------------------------------
 
 .. doxygenfunction:: hdf5::node::get_real_base
 
-:cpp:func:`get_group`
----------------------
+:cpp:func:`hdf5::node::get_group`
+---------------------------------
 
 .. doxygenfunction:: hdf5::node::get_group
 
-:cpp:func:`get_dataset`
------------------------
+:cpp:func:`hdf5::node::get_dataset`
+-----------------------------------
 
 .. doxygenfunction:: hdf5::node::get_dataset
 
-:cpp:func:`is_group`
---------------------
+:cpp:func:`hdf5::node::is_group`
+--------------------------------
 
 .. doxygenfunction:: hdf5::node::is_group
 
-:cpp:func:`is_dataset`
-----------------------
+:cpp:func:`hdf5::node::is_dataset`
+----------------------------------
 
 .. doxygenfunction:: hdf5::node::is_dataset
 
@@ -153,15 +153,15 @@ Functions
 Enumerations
 ============
 
-:cpp:enum:`NodeType`
---------------------
+:cpp:enum:`hdf5::node::NodeType`
+--------------------------------
 
 .. doxygenenum:: hdf5::node::NodeType
 
 .. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const NodeType &)
 
-:cpp:enum:`LinkType`
---------------------
+:cpp:enum:`hdf5::node::LinkType`
+--------------------------------
 
 .. doxygenenum:: hdf5::node::LinkType
 

--- a/doc/source/api_reference/namespace_node.rst
+++ b/doc/source/api_reference/namespace_node.rst
@@ -5,8 +5,8 @@ Namespace :cpp:any:`hdf5::node`
 Classes
 =======
 
-:cpp:class:`hdf5::node::Node`
------------------------------
+:cpp:class:`Node`
+-----------------
 
 .. doxygenclass:: hdf5::node::Node
    :members:
@@ -15,8 +15,8 @@ Classes
 
 .. doxygenfunction:: hdf5::node::operator!=(const Node &, const Node &)
 
-:cpp:class:`hdf5::node::Link`
------------------------------
+:cpp:class:`Link`
+-----------------
 
 .. doxygenclass:: hdf5::node::Link
    :members:
@@ -25,26 +25,26 @@ Classes
 
 .. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const Link &)
 
-:cpp:class:`hdf5::node::LinkTarget`
------------------------------------
+:cpp:class:`LinkTarget`
+-----------------------
 
 .. doxygenclass:: hdf5::node::LinkTarget
    :members:
 
-:cpp:class:`hdf5::node::Group`
-------------------------------
+:cpp:class:`Group`
+------------------
 
 .. doxygenclass:: hdf5::node::Group
    :members:
 
-:cpp:class:`hdf5::node::GroupView`
-----------------------------------
+:cpp:class:`GroupView`
+----------------------
 
 .. doxygenclass:: hdf5::node::GroupView
    :members:
 
-:cpp:class:`hdf5::node::NodeView`
----------------------------------
+:cpp:class:`NodeView`
+---------------------
 
 .. doxygenclass:: hdf5::node::NodeView
    :members:
@@ -55,8 +55,8 @@ Classes
 .. doxygenclass:: hdf5::node::RecursiveNodeIterator
    :members:
 
-:cpp:class:`hdf5::node::LinkView`
----------------------------------
+:cpp:class:`LinkView`
+---------------------
 
 .. doxygenclass:: hdf5::node::LinkView
    :members:
@@ -67,22 +67,22 @@ Classes
 .. doxygenclass:: hdf5::node::RecursiveLinkIterator
    :members:
 
-:cpp:class:`hdf5::node::Dataset`
---------------------------------
+:cpp:class:`Dataset`
+--------------------
 
 .. doxygenclass:: hdf5::node::Dataset
    :members:
 
 
-:cpp:class:`hdf5::node::ChunkedDataset`
----------------------------------------
+:cpp:class:`ChunkedDataset`
+---------------------------
 
 .. doxygenclass:: hdf5::node::ChunkedDataset
    :members:
 
 
-:cpp:class:`hdf5::node::VirtualDataset`
----------------------------------------
+:cpp:class:`VirtualDataset`
+---------------------------
 
 .. doxygenclass:: hdf5::node::VirtualDataset
    :members:
@@ -90,27 +90,27 @@ Classes
 Functions
 =========
 
-:cpp:func:`hdf5::node::copy`
-----------------------------
+:cpp:func:`copy`
+----------------
 
 .. doxygenfunction:: hdf5::node::copy(const Node &, const Group &, const property::ObjectCopyList &, const property::LinkCreationList &)
 
-:cpp:func:`hdf5::node::move`
-----------------------------
+:cpp:func:`move`
+----------------
 
 .. doxygenfunction:: hdf5::node::move(const Node &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
 .. doxygenfunction:: hdf5::node::move(const Node &, const Group &, const property::LinkCreationList &, const property::LinkAccessList &)
 
-:cpp:func:`hdf5::node::remove`
-------------------------------
+:cpp:func:`remove`
+------------------
 
 .. doxygenfunction:: hdf5::node::remove(const Node &, const property::LinkAccessList &)
 
 .. doxygenfunction:: hdf5::node::remove(const Group &, const Path &, const property::LinkAccessList &)
 
-:cpp:func:`hdf5::node::link`
-----------------------------
+:cpp:func:`link`
+----------------
 
 .. doxygenfunction:: hdf5::node::link(const Node &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
@@ -119,33 +119,33 @@ Functions
 .. doxygenfunction:: hdf5::node::link(const fs::path &, const Path &, const Group &, const Path &, const property::LinkCreationList &, const property::LinkAccessList &)
 
 
-:cpp:func:`hdf5::node::get_node`
---------------------------------
+:cpp:func:`get_node`
+--------------------
 
 .. doxygenfunction:: hdf5::node::get_node
 
-:cpp:func:`hdf5::node::get_real_base`
--------------------------------------
+:cpp:func:`get_real_base`
+-------------------------
 
 .. doxygenfunction:: hdf5::node::get_real_base
 
-:cpp:func:`hdf5::node::get_group`
----------------------------------
+:cpp:func:`get_group`
+---------------------
 
 .. doxygenfunction:: hdf5::node::get_group
 
-:cpp:func:`hdf5::node::get_dataset`
------------------------------------
+:cpp:func:`get_dataset`
+-----------------------
 
 .. doxygenfunction:: hdf5::node::get_dataset
 
-:cpp:func:`hdf5::node::is_group`
---------------------------------
+:cpp:func:`is_group`
+--------------------
 
 .. doxygenfunction:: hdf5::node::is_group
 
-:cpp:func:`hdf5::node::is_dataset`
-----------------------------------
+:cpp:func:`is_dataset`
+----------------------
 
 .. doxygenfunction:: hdf5::node::is_dataset
 
@@ -153,15 +153,15 @@ Functions
 Enumerations
 ============
 
-:cpp:enum:`hdf5::node::NodeType`
---------------------------------
+:cpp:enum:`NodeType`
+--------------------
 
 .. doxygenenum:: hdf5::node::NodeType
 
 .. doxygenfunction:: hdf5::node::operator<<(std::ostream &, const NodeType &)
 
-:cpp:enum:`hdf5::node::LinkType`
---------------------------------
+:cpp:enum:`LinkType`
+--------------------
 
 .. doxygenenum:: hdf5::node::LinkType
 

--- a/doc/source/api_reference/namespace_node.rst
+++ b/doc/source/api_reference/namespace_node.rst
@@ -149,6 +149,11 @@ Functions
 
 .. doxygenfunction:: hdf5::node::is_dataset
 
+:cpp:func:`resize_by`
+---------------------
+
+.. doxygenfunction:: hdf5::node::resize_by(const Dataset &, size_t, ssize_t)
+
 
 Enumerations
 ============

--- a/doc/source/api_reference/namespace_property.rst
+++ b/doc/source/api_reference/namespace_property.rst
@@ -226,3 +226,38 @@ Enumerations
 --------------------------
 
 .. doxygenenum:: hdf5::property::MPIChunkOption
+
+Property Class variables
+========================
+
+.. cpp:var:: const Class kAttributeCreate
+
+.. cpp:var:: const Class kDatasetAccess
+
+.. cpp:var:: const Class kDatasetCreate
+
+.. cpp:var:: const Class kDatasetXfer
+
+.. cpp:var:: const Class kDatatypeAccess
+
+.. cpp:var:: const Class kDatatypeCreate
+
+.. cpp:var:: const Class kFileAccess
+
+.. cpp:var:: const Class kFileCreate
+
+.. cpp:var:: const Class kFileMount
+
+.. cpp:var:: const Class kGroupAccess
+
+.. cpp:var:: const Class kGroupCreate
+
+.. cpp:var:: const Class kLinkAccess
+
+.. cpp:var:: const Class kLinkCreate
+
+.. cpp:var:: const Class kObjectCopy
+
+.. cpp:var:: const Class kObjectCreate
+
+.. cpp:var:: const Class kStringCreate

--- a/doc/source/api_reference/namespace_property.rst
+++ b/doc/source/api_reference/namespace_property.rst
@@ -5,43 +5,43 @@ Namespace :cpp:any:`hdf5::property`
 Enumerations
 ============
 
-:cpp:enum:`DatasetFillValueStatus`
-----------------------------------
+:cpp:enum:`hdf5::property::DatasetFillValueStatus`
+--------------------------------------------------
 
 .. doxygenenum:: hdf5::property::DatasetFillValueStatus
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetFillValueStatus &)
 
-:cpp:enum:`DatasetFillTime`
----------------------------
+:cpp:enum:`hdf5::property::DatasetFillTime`
+-------------------------------------------
 
 .. doxygenenum:: hdf5::property::DatasetFillTime
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetFillTime &)
 
-:cpp:enum:`DatasetAllocTime`
-----------------------------
+:cpp:enum:`hdf5::property::DatasetAllocTime`
+--------------------------------------------
 
 .. doxygenenum:: hdf5::property::DatasetAllocTime
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetAllocTime &)
 
-:cpp:enum:`DatasetLayout`
--------------------------
+:cpp:enum:`hdf5::property::DatasetLayout`
+-----------------------------------------
 
 .. doxygenenum:: hdf5::property::DatasetLayout
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetLayout &)
 
-:cpp:enum:`LibVersion`
-----------------------
+:cpp:enum:`hdf5::property::LibVersion`
+--------------------------------------
 
 .. doxygenenum:: hdf5::property::LibVersion
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const LibVersion &)
 
-:cpp:enum:`CopyFlag`
---------------------
+:cpp:enum:`hdf5::property::CopyFlag`
+------------------------------------
 
 .. doxygenenum:: hdf5::property::CopyFlag
 
@@ -49,8 +49,8 @@ Enumerations
 
 .. doxygenfunction:: hdf5::property::operator|(const CopyFlag &, const CopyFlag &)
 
-:cpp:enum:`VirtualDataView`
----------------------------
+:cpp:enum:`hdf5::property::VirtualDataView`
+-------------------------------------------
 
 .. doxygenenum:: hdf5::property::VirtualDataView
 
@@ -60,134 +60,134 @@ Enumerations
 Classes
 =======
 
-:cpp:class:`AttributeCreationList`
-----------------------------------
+:cpp:class:`hdf5::property::AttributeCreationList`
+--------------------------------------------------
 
 .. doxygenclass:: hdf5::property::AttributeCreationList
    :members:
    
-:cpp:class:`ChunkCacheParameters`
----------------------------------
+:cpp:class:`hdf5::property::ChunkCacheParameters`
+-------------------------------------------------
 
 .. doxygenclass:: hdf5::property::ChunkCacheParameters
    :members:
    
-:cpp:class:`Class`
-------------------
+:cpp:class:`hdf5::property::Class`
+----------------------------------
 
 .. doxygenclass:: hdf5::property::Class
    :members:
    
-:cpp:class:`CopyFlags`
-----------------------
+:cpp:class:`hdf5::property::CopyFlags`
+--------------------------------------
 
 .. doxygenclass:: hdf5::property::CopyFlags
    :members:
    
-:cpp:class:`CreationOrder`
---------------------------
+:cpp:class:`hdf5::property::CreationOrder`
+------------------------------------------
 
 .. doxygenclass:: hdf5::property::CreationOrder
    :members:
    
-:cpp:class:`DatasetAccessList`
-------------------------------
+:cpp:class:`hdf5::property::DatasetAccessList`
+----------------------------------------------
 
 .. doxygenclass:: hdf5::property::DatasetAccessList
    :members:
    
-:cpp:class:`DatasetCreationList`
---------------------------------
+:cpp:class:`hdf5::property::DatasetCreationList`
+------------------------------------------------
 
 .. doxygenclass:: hdf5::property::DatasetCreationList
    :members:
    
-:cpp:class:`DatasetTransferList`
---------------------------------
+:cpp:class:`hdf5::property::DatasetTransferList`
+------------------------------------------------
 
 .. doxygenclass:: hdf5::property::DatasetTransferList
    :members:
    
-:cpp:class:`DatatypeAccessList`
--------------------------------
+:cpp:class:`hdf5::property::DatatypeAccessList`
+-----------------------------------------------
 
 .. doxygenclass:: hdf5::property::DatatypeAccessList
    :members:
    
-:cpp:class:`FileAccessList`
----------------------------
+:cpp:class:`hdf5::property::FileAccessList`
+-------------------------------------------
 
 .. doxygenclass:: hdf5::property::FileAccessList
    :members:
    
-:cpp:class:`FileCreationList`
------------------------------
+:cpp:class:`hdf5::property::FileCreationList`
+---------------------------------------------
 
 .. doxygenclass:: hdf5::property::FileCreationList
    :members:
    
-:cpp:class:`FileMountList`
---------------------------
+:cpp:class:`hdf5::property::FileMountList`
+------------------------------------------
 
 .. doxygenclass:: hdf5::property::FileMountList
    :members:
    
-:cpp:class:`GroupAccessList`
-----------------------------
+:cpp:class:`hdf5::property::GroupAccessList`
+--------------------------------------------
 
 .. doxygenclass:: hdf5::property::GroupAccessList
    :members:
    
-:cpp:class:`GroupCreationList`
-------------------------------
+:cpp:class:`hdf5::property::GroupCreationList`
+----------------------------------------------
 
 .. doxygenclass:: hdf5::property::GroupCreationList
    :members:
    
-:cpp:class:`LinkAccessList`
----------------------------
+:cpp:class:`hdf5::property::LinkAccessList`
+-------------------------------------------
 
 .. doxygenclass:: hdf5::property::LinkAccessList
    :members:
    
-:cpp:class:`LinkCreationList`
------------------------------
+:cpp:class:`hdf5::property::LinkCreationList`
+---------------------------------------------
 
 .. doxygenclass:: hdf5::property::LinkCreationList
    :members:
    
-:cpp:class:`List`
------------------
+:cpp:class:`hdf5::property::List`
+---------------------------------
 
 .. doxygenclass:: hdf5::property::List
    :members:
    
-:cpp:class:`ObjectCopyList`
----------------------------
+:cpp:class:`hdf5::property::ObjectCopyList`
+-------------------------------------------
 
 .. doxygenclass:: hdf5::property::ObjectCopyList
    :members:
    
-:cpp:class:`ObjectCreationList`
--------------------------------
+:cpp:class:`hdf5::property::ObjectCreationList`
+-----------------------------------------------
 
 .. doxygenclass:: hdf5::property::ObjectCreationList
    :members:
    
-:cpp:class:`StringCreationList`
--------------------------------
+:cpp:class:`hdf5::property::StringCreationList`
+-----------------------------------------------
 
 .. doxygenclass:: hdf5::property::StringCreationList
    :members:
    
-:cpp:class:`TypeCreationList`
------------------------------
+:cpp:class:`hdf5::property::TypeCreationList`
+---------------------------------------------
 
 .. doxygenclass:: hdf5::property::TypeCreationList
    :members:
    
-:cpp:class:`VirtualDataMap`
----------------------------
+:cpp:class:`hdf5::property::VirtualDataMap`
+-------------------------------------------
 
 .. doxygenclass:: hdf5::property::VirtualDataMap
    :members:

--- a/doc/source/api_reference/namespace_property.rst
+++ b/doc/source/api_reference/namespace_property.rst
@@ -2,195 +2,227 @@
 Namespace :cpp:any:`hdf5::property`
 ===================================
 
+Classes
+=======
+
+:cpp:class:`AttributeCreationList`
+----------------------------------
+
+.. doxygenclass:: hdf5::property::AttributeCreationList
+   :members:
+
+:cpp:class:`ChunkCacheParameters`
+---------------------------------
+
+.. doxygenclass:: hdf5::property::ChunkCacheParameters
+   :members:
+
+:cpp:class:`Class`
+------------------
+
+.. doxygenclass:: hdf5::property::Class
+   :members:
+
+.. doxygenfunction:: hdf5::property::operator==(const Class &, const Class &)
+
+.. doxygenfunction:: hdf5::property::operator!=(const Class &, const Class &)
+
+:cpp:class:`CopyFlags`
+----------------------
+
+.. doxygenclass:: hdf5::property::CopyFlags
+   :members:
+
+:cpp:class:`CreationOrder`
+--------------------------
+
+.. doxygenclass:: hdf5::property::CreationOrder
+   :members:
+
+:cpp:class:`DatasetAccessList`
+------------------------------
+
+.. doxygenclass:: hdf5::property::DatasetAccessList
+   :members:
+
+:cpp:class:`DatasetCreationList`
+--------------------------------
+
+.. doxygenclass:: hdf5::property::DatasetCreationList
+   :members:
+
+:cpp:class:`DatasetTransferList`
+--------------------------------
+
+.. doxygenclass:: hdf5::property::DatasetTransferList
+   :members:
+
+:cpp:class:`DatatypeAccessList`
+-------------------------------
+
+.. doxygenclass:: hdf5::property::DatatypeAccessList
+   :members:
+
+:cpp:class:`FileAccessList`
+---------------------------
+
+.. doxygenclass:: hdf5::property::FileAccessList
+   :members:
+
+:cpp:class:`FileCreationList`
+-----------------------------
+
+.. doxygenclass:: hdf5::property::FileCreationList
+   :members:
+
+:cpp:class:`FileMountList`
+--------------------------
+
+.. doxygenclass:: hdf5::property::FileMountList
+   :members:
+
+:cpp:class:`GroupAccessList`
+----------------------------
+
+.. doxygenclass:: hdf5::property::GroupAccessList
+   :members:
+
+:cpp:class:`GroupCreationList`
+------------------------------
+
+.. doxygenclass:: hdf5::property::GroupCreationList
+   :members:
+
+:cpp:class:`LinkAccessList`
+---------------------------
+
+.. doxygenclass:: hdf5::property::LinkAccessList
+   :members:
+
+:cpp:class:`LinkCreationList`
+-----------------------------
+
+.. doxygenclass:: hdf5::property::LinkCreationList
+   :members:
+
+:cpp:class:`List`
+-----------------
+
+.. doxygenclass:: hdf5::property::List
+   :members:
+
+:cpp:class:`ObjectCopyList`
+---------------------------
+
+.. doxygenclass:: hdf5::property::ObjectCopyList
+   :members:
+
+:cpp:class:`ObjectCreationList`
+-------------------------------
+
+.. doxygenclass:: hdf5::property::ObjectCreationList
+   :members:
+
+:cpp:class:`StringCreationList`
+-------------------------------
+
+.. doxygenclass:: hdf5::property::StringCreationList
+   :members:
+
+:cpp:class:`TypeCreationList`
+-----------------------------
+
+.. doxygenclass:: hdf5::property::TypeCreationList
+   :members:
+
+:cpp:class:`VirtualDataMap`
+---------------------------
+
+.. doxygenclass:: hdf5::property::VirtualDataMap
+   :members:
+
+.. doxygenclass:: hdf5::property::VirtualDataMaps
+   :members:
+
 Enumerations
 ============
 
-:cpp:enum:`hdf5::property::DatasetFillValueStatus`
---------------------------------------------------
+:cpp:enum:`DatasetFillValueStatus`
+----------------------------------
 
 .. doxygenenum:: hdf5::property::DatasetFillValueStatus
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetFillValueStatus &)
 
-:cpp:enum:`hdf5::property::DatasetFillTime`
--------------------------------------------
+:cpp:enum:`DatasetFillTime`
+---------------------------
 
 .. doxygenenum:: hdf5::property::DatasetFillTime
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetFillTime &)
 
-:cpp:enum:`hdf5::property::DatasetAllocTime`
---------------------------------------------
+:cpp:enum:`DatasetAllocTime`
+----------------------------
 
 .. doxygenenum:: hdf5::property::DatasetAllocTime
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetAllocTime &)
 
-:cpp:enum:`hdf5::property::DatasetLayout`
------------------------------------------
+:cpp:enum:`DatasetLayout`
+-------------------------
 
 .. doxygenenum:: hdf5::property::DatasetLayout
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const DatasetLayout &)
 
-:cpp:enum:`hdf5::property::LibVersion`
---------------------------------------
+:cpp:enum:`LibVersion`
+----------------------
 
 .. doxygenenum:: hdf5::property::LibVersion
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const LibVersion &)
 
-:cpp:enum:`hdf5::property::CopyFlag`
-------------------------------------
+:cpp:enum:`CopyFlag` and :cpp:type:`CopyFlags`
+----------------------------------------------
 
 .. doxygenenum:: hdf5::property::CopyFlag
 
-.. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const CopyFlag &)
-
 .. doxygenfunction:: hdf5::property::operator|(const CopyFlag &, const CopyFlag &)
 
-:cpp:enum:`hdf5::property::VirtualDataView`
--------------------------------------------
+.. doxygenfunction:: hdf5::property::operator|(const CopyFlags &, const CopyFlag &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator|(const CopyFlag &, const CopyFlags &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator|(const CopyFlags &, const CopyFlags &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator&(const CopyFlag &, const CopyFlag &)
+
+.. doxygenfunction:: hdf5::property::operator&(const CopyFlags &, const CopyFlag &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator&(const CopyFlag &, const CopyFlags &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator&(const CopyFlags &, const CopyFlags &) noexcept
+
+.. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const CopyFlag &)
+
+:cpp:enum:`VirtualDataView`
+---------------------------
 
 .. doxygenenum:: hdf5::property::VirtualDataView
 
 .. doxygenfunction:: hdf5::property::operator<<(std::ostream &, const VirtualDataView &)
 
+:cpp:enum:`CloseDegree`
+-----------------------
 
-Classes
-=======
+.. doxygenenum:: hdf5::property::CloseDegree
 
-:cpp:class:`hdf5::property::AttributeCreationList`
---------------------------------------------------
+:cpp:enum:`MPITransferMode`
+---------------------------
 
-.. doxygenclass:: hdf5::property::AttributeCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::ChunkCacheParameters`
--------------------------------------------------
+.. doxygenenum:: hdf5::property::MPITransferMode
 
-.. doxygenclass:: hdf5::property::ChunkCacheParameters
-   :members:
-   
-:cpp:class:`hdf5::property::Class`
-----------------------------------
+:cpp:enum:`MPIChunkOption`
+--------------------------
 
-.. doxygenclass:: hdf5::property::Class
-   :members:
-   
-:cpp:class:`hdf5::property::CopyFlags`
---------------------------------------
-
-.. doxygenclass:: hdf5::property::CopyFlags
-   :members:
-   
-:cpp:class:`hdf5::property::CreationOrder`
-------------------------------------------
-
-.. doxygenclass:: hdf5::property::CreationOrder
-   :members:
-   
-:cpp:class:`hdf5::property::DatasetAccessList`
-----------------------------------------------
-
-.. doxygenclass:: hdf5::property::DatasetAccessList
-   :members:
-   
-:cpp:class:`hdf5::property::DatasetCreationList`
-------------------------------------------------
-
-.. doxygenclass:: hdf5::property::DatasetCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::DatasetTransferList`
-------------------------------------------------
-
-.. doxygenclass:: hdf5::property::DatasetTransferList
-   :members:
-   
-:cpp:class:`hdf5::property::DatatypeAccessList`
------------------------------------------------
-
-.. doxygenclass:: hdf5::property::DatatypeAccessList
-   :members:
-   
-:cpp:class:`hdf5::property::FileAccessList`
--------------------------------------------
-
-.. doxygenclass:: hdf5::property::FileAccessList
-   :members:
-   
-:cpp:class:`hdf5::property::FileCreationList`
----------------------------------------------
-
-.. doxygenclass:: hdf5::property::FileCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::FileMountList`
-------------------------------------------
-
-.. doxygenclass:: hdf5::property::FileMountList
-   :members:
-   
-:cpp:class:`hdf5::property::GroupAccessList`
---------------------------------------------
-
-.. doxygenclass:: hdf5::property::GroupAccessList
-   :members:
-   
-:cpp:class:`hdf5::property::GroupCreationList`
-----------------------------------------------
-
-.. doxygenclass:: hdf5::property::GroupCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::LinkAccessList`
--------------------------------------------
-
-.. doxygenclass:: hdf5::property::LinkAccessList
-   :members:
-   
-:cpp:class:`hdf5::property::LinkCreationList`
----------------------------------------------
-
-.. doxygenclass:: hdf5::property::LinkCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::List`
----------------------------------
-
-.. doxygenclass:: hdf5::property::List
-   :members:
-   
-:cpp:class:`hdf5::property::ObjectCopyList`
--------------------------------------------
-
-.. doxygenclass:: hdf5::property::ObjectCopyList
-   :members:
-   
-:cpp:class:`hdf5::property::ObjectCreationList`
------------------------------------------------
-
-.. doxygenclass:: hdf5::property::ObjectCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::StringCreationList`
------------------------------------------------
-
-.. doxygenclass:: hdf5::property::StringCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::TypeCreationList`
----------------------------------------------
-
-.. doxygenclass:: hdf5::property::TypeCreationList
-   :members:
-   
-:cpp:class:`hdf5::property::VirtualDataMap`
--------------------------------------------
-
-.. doxygenclass:: hdf5::property::VirtualDataMap
-   :members:
-   
-.. doxygenclass:: hdf5::property::VirtualDataMaps
-   :members:
+.. doxygenenum:: hdf5::property::MPIChunkOption

--- a/doc/source/conf.py.in
+++ b/doc/source/conf.py.in
@@ -360,4 +360,4 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 # workaround fix for qualifiers error
-cpp_id_attributes = ["DLL_EXPORT", "friend"]
+cpp_id_attributes = ["DLL_EXPORT", "friend", "extern"]

--- a/src/h5cpp/attribute/attribute_manager.hpp
+++ b/src/h5cpp/attribute/attribute_manager.hpp
@@ -123,7 +123,7 @@ class DLL_EXPORT AttributeManager
     //! \brief rename an attribute
     //!
     //! \throws std::runtime_error in case of a failure
-    //! \param old_name _name the old name of the attribute
+    //! \param old_name old name of the attribute
     //! \param new_name new name of the attribute
     //!
     void rename(const std::string &old_name,const std::string &new_name) const;

--- a/src/h5cpp/core/object_id.hpp
+++ b/src/h5cpp/core/object_id.hpp
@@ -94,10 +94,12 @@ class DLL_EXPORT ObjectId
     //!
     bool operator< (const ObjectId& other) const;
 
+#ifndef _DOXYGEN_ /* workaround for the #613 breathe bug */
     //!
     //! @brief stream output operator for ObjectId class
     //!
     DLL_EXPORT friend std::ostream & operator<<(std::ostream &os, const ObjectId& p);
+#endif /* DOXYGEN */
 
     //!
     //! \brief Get the HDF5 file number
@@ -164,5 +166,11 @@ class DLL_EXPORT ObjectId
 #endif
 };
 
+#ifdef _DOXYGEN_ /* workaround for the #613 breathe bug */
+    //!
+    //! @brief stream output operator for ObjectId class
+    //!
+    DLL_EXPORT friend std::ostream & operator<<(std::ostream &os, const ObjectId& p);
+#endif /* DOXYGEN */
 
 }

--- a/src/h5cpp/core/path.hpp
+++ b/src/h5cpp/core/path.hpp
@@ -260,13 +260,17 @@ class DLL_EXPORT Path
 
     Path& operator+=(const Path &other);
 
+#ifndef _DOXYGEN_ /* workaround for the #613 breathe bug */
     //!
     //! \brief checks two paths for equality
     //!
     //! Two paths are considered equal if each of their elements is
     DLL_EXPORT friend bool operator==(const Path &lhs, const Path &rhs);
+    //!
+    //! \brief checks two paths for equality base
+    //!
     DLL_EXPORT friend Path common_base(const Path& lhs, const Path& rhs);
-
+#endif /* DOXYGEN */
   private:
     bool absolute_;
 #ifdef _MSC_VER
@@ -287,6 +291,17 @@ class DLL_EXPORT Path
 #pragma clang diagnostic pop
 #endif
 
+#ifdef _DOXYGEN_ /* workaround for the #613 breathe bug */
+    //!
+    //! \brief checks two paths for equality
+    //!
+    //! Two paths are considered equal if each of their elements is
+    DLL_EXPORT friend bool operator==(const Path &lhs, const Path &rhs);
+    //!
+    //! \brief checks two paths for equality base
+    //!
+    DLL_EXPORT friend Path common_base(const Path& lhs, const Path& rhs);
+#endif /* DOXYGEN */
 
 DLL_EXPORT bool operator!=(const Path &lhs, const Path &rhs);
 

--- a/src/h5cpp/core/version.hpp
+++ b/src/h5cpp/core/version.hpp
@@ -97,7 +97,6 @@ class DLL_EXPORT Version
 
 //!
 //! @brief output stream operator
-//! @relates Version
 //!
 //! Writes an instance of Version to a std::ostream. The output format is the
 //! same as for Version::to_string.
@@ -111,7 +110,6 @@ DLL_EXPORT std::ostream &operator<<(std::ostream &stream,const Version &version)
 
 //!
 //! @brief checks two version for equality
-//! @relates Version
 //!
 //! Two version are considered equal if all of their parts are equal.
 //!
@@ -123,7 +121,6 @@ DLL_EXPORT bool operator==(const Version &lhs,const Version &rhs);
 
 //!
 //! @brief checks if two versions are not equal
-//! @relates Version
 //!
 //! @param lhs reference to the left hand side version
 //! @param rhs reference to the right hand side version
@@ -141,7 +138,6 @@ DLL_EXPORT bool operator<=(const Version &lhs,const Version &rhs);
 
 //!
 //! @brief checks if the left version is strictly small than the right
-//! @relates Version
 //!
 //! @param lhs reference to the left hand side version
 //! @param rhs reference to the right hand side version
@@ -150,7 +146,6 @@ DLL_EXPORT bool operator<(const Version &lhs,const Version &rhs);
 
 //!
 //! @brief checks if the left version is bigger or equal than the right
-//! @relates Version
 //!
 //! @param lhs reference to the left hand side version
 //! @param rhs reference to the right hand side version
@@ -159,7 +154,6 @@ DLL_EXPORT bool operator>=(const Version &lhs,const Version &rhs);
 
 //!
 //! @brief checks if the left version is strictly bigger than the right
-//! @relates Version
 //!
 //! @param lhs reference to the left hand side version
 //! @param rhs reference to the right hand side version
@@ -168,7 +162,6 @@ DLL_EXPORT bool operator>(const Version &lhs,const Version &rhs);
 
 //!
 //! @brief returns the current version of the HDF5 library
-//! @relates Version
 //!
 //! @throws std::runtime_error in case of a failure
 //! @return instance of Version with the current HDF5 version

--- a/src/h5cpp/datatype/datatype.hpp
+++ b/src/h5cpp/datatype/datatype.hpp
@@ -170,7 +170,6 @@ class DLL_EXPORT Datatype
 
 //!
 //! @brief equality check for datatypes
-//! @relates Datatype
 //!
 //! Returns if two datatypes are equal. Datatypes are considered equal if
 //! they represent the same type.
@@ -183,7 +182,6 @@ DLL_EXPORT bool operator==(const Datatype &lhs, const Datatype &rhs);
 
 //!
 //! @brief inequality check for datatypes
-//! @relates Datatype
 //!
 //! Returns true if both datatypes do not represent the same types.
 //!


### PR DESCRIPTION
It resolves #556 by add missing classes and functions to the sphinx API reference documentation.

It looks like in the current configuration doxygen/breathe/sphinx cannot link correctly `operator&`
```
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:45: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:47: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:49: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:66: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:68: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:70: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:87: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:89: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_file.rst:91: WARNING: doxygenfunction: Cannot find function "hdf5::file::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_property.rst:198: WARNING: doxygenfunction: Cannot find function "hdf5::property::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_property.rst:200: WARNING: doxygenfunction: Cannot find function "hdf5::property::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_property.rst:202: WARNING: doxygenfunction: Cannot find function "hdf5::property::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
/home/jenkins/build/doc/source/api_reference/namespace_property.rst:204: WARNING: doxygenfunction: Cannot find function "hdf5::property::operator&" in doxygen xml output for project "h5cpp" from directory: /home/jenkins/build/doc/source/../doxygen_xml
looking for now-outdated files... none found
```
It works without warnings on my local installation on debian11 so to fix it I propose to open a new ticket to found doxygen/breathe/sphinx versions working together correctly.