### PR TITLE
Issue 574: update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ for the library, using it should be the same on each of these platforms.
 
 The minimum requirements for building the library are:
 
-* a C++ compiler, gcc>=4.8.1 should do well
+* a C++ compiler, gcc>=4.9 should do well
 * the HDF5 C library (>=1.8.13 would do but >=1.10.0 is prefered)
-* cmake >= 3.0
+* cmake >= 3.10
 * _either_ the boost libraries _or_ a compiler with std::filesystem or std::experimental::filesystem (and specify H5CPP_WITH_BOOST=OFF to CMake)
+* [sphinx](http://www.sphinx-doc.org/en/stable/), [breathe](https://github.com/michaeljones/breathe) (with python) and  [doxygen](https://www.doxygen.nl/index.html) for the documentation build
 
 The external library dependencies can be acquired and built using [Conan](https://conan.io/). Conan can be installed with PyPI: 
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The minimum requirements for building the library are:
 * cmake >= 3.10
 * _either_ the boost libraries _or_ a compiler with std::filesystem or std::experimental::filesystem (and specify H5CPP_WITH_BOOST=OFF to CMake)
 * [sphinx](http://www.sphinx-doc.org/en/stable/), [breathe](https://github.com/michaeljones/breathe) (with python) and  [doxygen](https://www.doxygen.nl/index.html) for the documentation build
+* [catch2](https://github.com/catchorg/catch2) to build the unit tests
 
 The external library dependencies can be acquired and built using [Conan](https://conan.io/). Conan can be installed with PyPI: 
 ```

--- a/doc/source/users_guide/installing.rst
+++ b/doc/source/users_guide/installing.rst
@@ -16,16 +16,17 @@ In order to build the code you need
   (gcc>=4.9,Micrsoft Developer Studio >= 2015)
 * the `Boost`_ libraries or a compiler with std::filesystem or std::experimental::filesystem
 * the `HDF5`_ C library
-* `googletest`_ to build the unit tests
-* `sphinx`_ (with python) and  `doxygen`_ for the documentation build
-* `cmake`_ >= 3.0
+* `catch2`_ to build the unit tests
+* `sphinx`_ , `breathe`_ (with python) and  `doxygen`_ for the documentation build
+* `cmake`_ >= 3.10
 
 .. _cmake: https://cmake.org/
 .. _sphinx: http://www.sphinx-doc.org/en/stable/
+.. _breathe: https://github.com/michaeljones/breathe
 .. _HDF5: https://support.hdfgroup.org/HDF5/
 .. _Boost: http://www.boost.org/
-.. _doxygen: http://www.stack.nl/~dimitri/doxygen/index.html
-.. _googletest: https://github.com/google/googletest
+.. _doxygen: https://www.doxygen.nl/index.html
+.. _catch2: https://github.com/catchorg/catch2
 
 Getting the code
 ----------------


### PR DESCRIPTION
It resolves #574 by updating cmake version in the documentation and add catch2