### PR TITLE
Issue 586: fix H5O_info_t_  definition

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -89,7 +89,9 @@ jobs:
     strategy:
       matrix:
         shared: ["shared", "static"]
-        boost: ["boost", "stdfs"]
+        boost: [
+        # "boost",
+        "stdfs"]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -139,7 +141,9 @@ jobs:
     strategy:
       matrix:
         shared: ["shared", "static"]
-        boost: ["boost", "stdfs"]
+        boost: [
+        # "boost",
+        "stdfs"]
         mpi: ["serial", "mpi"]
     runs-on: macos-10.15
     steps:

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,9 @@ class H5CppConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.with_mpi
+            del self.options.with_boost
+        if self.settings.os == "Macos":
+            del self.options.with_boost
 
     def configure(self):
         if self.options.get_safe("with_mpi", False):
@@ -33,8 +36,13 @@ class H5CppConan(ConanFile):
 
     def requirements(self):
         self.requires("hdf5/1.12.0")
-        if self.options.with_boost:
-            self.requires("boost/1.77.0")
+        if self.options.get_safe("with_boost", False):
+            if self.settings.os == "Windows":
+                self.requires("boost/1.77.0")
+            elif self.settings.os == "Macos":
+                self.requires("boost/1.77.0")
+            else:
+                self.requires("boost/1.77.0@#35c2c19753eaadacfb846c7198919da7")
         if self.options.get_safe("with_mpi", False):
             self.requires("openmpi/4.1.0")
 
@@ -43,7 +51,8 @@ class H5CppConan(ConanFile):
         cmake.definitions.update({
             "H5CPP_CONAN": "MANUAL",
             "H5CPP_WITH_MPI": self.options.get_safe("with_mpi", False),
-            "H5CPP_WITH_BOOST": self.options.with_boost
+            "H5CPP_WITH_BOOST": self.options.get_safe(
+                "with_boost", False),
         })
         with tools.run_environment(self):
             cmake.configure()

--- a/src/h5cpp/core/object_id.hpp
+++ b/src/h5cpp/core/object_id.hpp
@@ -128,10 +128,10 @@ class DLL_EXPORT ObjectId
     //! Obtains the name of the file where the object is stored in.
     static std::string get_file_name(const ObjectHandle &handle);
 
-#if H5_VERSION_LE(1,10,6)
-#define H5O_info_t_ H5O_info_t
-#else
+#if H5_VERSION_GE(1,11,0)
 #define H5O_info_t_ H5O_info1_t
+#else
+#define H5O_info_t_ H5O_info_t
 #endif
 
     //!H5O_info_t


### PR DESCRIPTION
It resolves #586 by fixing the `H5O_info_t_`  definition for libhdf5 1.10.7