### PR TITLE
Issue 595: add hdf5::hdf5_hl to test node link target for older libhdf5 e.g. 1.10.0

### DIFF
--- a/test/node/CMakeLists.txt
+++ b/test/node/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
    PRIVATE
        h5cpp
        hdf5::hdf5
+       hdf5::hdf5_hl
        example_lib
 )
 target_compile_definitions(node_test PRIVATE CATCH_CONFIG_ENABLE_BENCHMARKING)


### PR DESCRIPTION
It resolves #595 by adding hdf5::hdf5_hl to test node link target for older libhdf5 e.g. 1.10.0