### PR TITLE
Issue 611: avoid interference with the windows max macro

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,11 +35,11 @@ class H5CppConan(ConanFile):
         self.requires("hdf5/1.12.2")
         if self.options.get_safe("with_boost", False):
             if self.settings.os == "Windows":
-                self.requires("boost/1.77.0")
+                self.requires("boost/1.69.0")
             elif self.settings.os == "Macos":
-                self.requires("boost/1.77.0")
+                self.requires("boost/1.69.0")
             else:
-                self.requires("boost/1.77.0")
+                self.requires("boost/1.69.0")
         if self.options.get_safe("with_mpi", False):
             self.requires("openmpi/4.1.0")
 

--- a/src/h5cpp/core/utilities.hpp
+++ b/src/h5cpp/core/utilities.hpp
@@ -61,7 +61,7 @@ TType unsigned2signed(SType &&source_value) {
   using target_limits = std::numeric_limits<stripped_target_t>;
   // if the source value is smaller than the maximum positive value of the 
   // signed target type
-  if(source_value <= static_cast<stripped_source_t>(target_limits::max())) {
+  if(source_value <= static_cast<stripped_source_t>((target_limits::max)())) {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"
@@ -96,7 +96,7 @@ TType signed2unsigned(SType &&source_value) {
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wsign-conversion"
 #endif
-  if(static_cast<stripped_target_t>(source_value) <= target_limits::max()) {
+  if(static_cast<stripped_target_t>(source_value) <= (target_limits::max)()) {
 	  return static_cast<stripped_target_t>(std::forward<SType>(source_value));
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/test/node/dataset_io_speed_test.cpp
+++ b/test/node/dataset_io_speed_test.cpp
@@ -82,9 +82,9 @@ class create {
     return file::create(filename, file::AccessFlags::Truncate, fcpl(), fapl());
   }
   static dataspace::Simple ds(Dimensions current) {
-    Dimensions max(current.size());
-    std::fill(std::begin(max), std::end(max), dataspace::Simple::unlimited);
-    return dataspace::Simple(current, max);
+    Dimensions dmax(current.size());
+    std::fill(std::begin(dmax), std::end(dmax), dataspace::Simple::unlimited);
+    return dataspace::Simple(current, dmax);
   }
 
   static UShorts buffer(size_t size) {


### PR DESCRIPTION
It resolves #611 by adding additional brackets to max function calls and renaming `max` to `dmax` in tests.