### PR TITLE
Remove reference to ESS Conan Artifactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ pip install conan
 ```
 Then run the following to configure required Conan repositories:
 ```
-conan remote add ecdc https://artifactoryconan.esss.dk/artifactory/api/conan/ecdc
 conan remote add bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
 ```
 and that's it, CMake will handle the rest!

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,11 +35,11 @@ class H5CppConan(ConanFile):
         self.requires("hdf5/1.12.2")
         if self.options.get_safe("with_boost", False):
             if self.settings.os == "Windows":
-                self.requires("boost/1.69.0")
+                self.requires("boost/1.77.0")
             elif self.settings.os == "Macos":
-                self.requires("boost/1.69.0")
+                self.requires("boost/1.77.0")
             else:
-                self.requires("boost/1.69.0")
+                self.requires("boost/1.77.0")
         if self.options.get_safe("with_mpi", False):
             self.requires("openmpi/4.1.0")
 


### PR DESCRIPTION
The DMSC Conan Artifactory server is being replaced, and is not needed for building h5cpp.
Closes #614.