### PR TITLE
Add further choices for LibVersion

### DIFF
--- a/src/h5cpp/property/file_access.cpp
+++ b/src/h5cpp/property/file_access.cpp
@@ -36,7 +36,20 @@ namespace property {
 std::ostream &operator<<(std::ostream &stream, const LibVersion &version) {
   switch (version) {
     case LibVersion::Earliest: return stream << "EARLIEST";
+#if H5_VERSION_LE(1,10,1)
+    // starting with 1.10.2 "Latest" is mapped to the specific latest version
     case LibVersion::Latest: return stream << "LATEST";
+#endif
+#if H5_VERSION_GE(1,10,2)
+    case LibVersion::V18: return stream << "V18";
+    case LibVersion::V110: return stream << "V110";
+#endif
+#if H5_VERSION_GE(1,12,0)
+    case LibVersion::V112: return stream << "V112";
+#endif
+#if H5_VERSION_GE(1,13,0)
+    case LibVersion::V114: return stream << "V114";
+#endif
   }
   return stream;
 }

--- a/src/h5cpp/property/file_access.hpp
+++ b/src/h5cpp/property/file_access.hpp
@@ -39,6 +39,16 @@ namespace property {
 //!
 enum class LibVersion : std::underlying_type<H5F_libver_t>::type {
   Latest = H5F_LIBVER_LATEST,
+#if H5_VERSION_GE(1,10,2)
+  V18 = H5F_LIBVER_V18,
+  V110 = H5F_LIBVER_V110,
+#endif
+#if H5_VERSION_GE(1,12,0)
+  V112 = H5F_LIBVER_V112,
+#endif
+#if H5_VERSION_GE(1,13,0)
+  V114 = H5F_LIBVER_V114,
+#endif
   Earliest = H5F_LIBVER_EARLIEST
 };
 


### PR DESCRIPTION
Implements #648 by adding additional choices for `hdf5::property::LibVersion`. The available choices are constraint based on the available version of HDF5:
- Starting with v1.10.2: V18 and V110
- Starting with v1.12.0: V112
- Starting with v1.13.0 (!): V114
- The current master which is bound to become 1.15 one day will additionally add V116 (not yet included in the PR)

One important thing to notice:  
When the specific versions (V18, V110, etc.) where first introduced in v1.10.2, `HDF5_LIBVER_LATEST` was removed from the `H5F_libver_t` enum and instead `#define`'d to refer to the actual latest version among the now added enum values `V18`, `V110`, etc. Therefore, starting with v1.10.2 `LibVersion::Latest` is no longer distinguishable from the actual latest version (e.g., `LibVersion::V110`). I therefore removed the printing of "Latest" in favor of printing the actual version number in case `LibVersion::Latest` was specified. I did not see a better alternative, as the cases in this [switch-statement](https://github.com/ess-dmsc/h5cpp/blob/d0184283159631606aa4ec3972057385460d41f2/src/h5cpp/property/file_access.cpp#L37-L53) need to remain disjoint.