### PR TITLE
Destroy `Node`'s handle before its `Link`

### DIFF
--- a/src/h5cpp/node/node.cpp
+++ b/src/h5cpp/node/node.cpp
@@ -32,20 +32,20 @@ namespace node {
 
 Node::Node():
     attributes(*this),
-    handle_(),
-    link_()
+    link_(),
+    handle_()
 {}
 
 Node::Node(ObjectHandle &&handle,const Link &link):
     attributes(*this),
-    handle_(std::move(handle)),
-    link_(link)
+    link_(link),
+    handle_(std::move(handle))
 {}
 
 Node::Node(const Node &node):
     attributes(*this),
-    handle_(node.handle_),
-    link_(node.link_)
+    link_(node.link_),
+    handle_(node.handle_)
 {}
 
 Node &Node::operator=(const Node &node)

--- a/src/h5cpp/node/node.hpp
+++ b/src/h5cpp/node/node.hpp
@@ -130,8 +130,8 @@ class DLL_EXPORT Node
     attribute::AttributeManager attributes;
 
   private:
-    ObjectHandle handle_; //!< access handle to the object
     Link link_;           //!< stores the link to the object
+    ObjectHandle handle_; //!< access handle to the object
 };
 
 DLL_EXPORT bool operator==(const Node &lhs, const Node &rhs);


### PR DESCRIPTION
Fixes #659.

Nodes must first delete the handle to the underlying hdf5 resource before deleting their link.
Otherwise (i.e., link is deleted first), hdf5 attempts to close the file (if this was the last node referencing the file), which might fail (e.g., when using mpi-io, or close degree `Semi`) because the handle to the node would still be around.

I tried to add a test for this, but unfortunately the error message originates from the destructor of `ObjectHandle` catching any exception and only printing an error to stderr [here](https://github.com/ess-dmsc/h5cpp/blob/master/src/h5cpp/core/object_handle.cpp#L84-L93) without rethrowing to maintain `noexept`'ness and I could not find a sensible way to check what is printed to stderr within a catch2 test.