### PR TITLE
Destroy `Attributes'`s handle before its parent_link

### DIFF
--- a/src/h5cpp/attribute/attribute.cpp
+++ b/src/h5cpp/attribute/attribute.cpp
@@ -34,8 +34,8 @@ namespace hdf5 {
 namespace attribute {
 
 Attribute::Attribute(ObjectHandle &&handle,const node::Link &parent_link):
-    handle_(std::move(handle)),
-    parent_link_(parent_link)
+    parent_link_(parent_link),
+    handle_(std::move(handle))
 {
 }
 

--- a/src/h5cpp/attribute/attribute.hpp
+++ b/src/h5cpp/attribute/attribute.hpp
@@ -203,8 +203,8 @@ class DLL_EXPORT Attribute
     void read(T &data,const datatype::Datatype &mem_type) const;
 
   private:
-    ObjectHandle handle_;
     node::Link   parent_link_;
+    ObjectHandle handle_;
 
     template<typename T>
     void read(T &data,const datatype::Datatype &mem_type, const datatype::Datatype &file_type) const;


### PR DESCRIPTION
As pointed out by @jkotan in [a comment](https://github.com/ess-dmsc/h5cpp/pull/660#issuecomment-2530695551) to the related PR #660, the same issue as described in #659 also appears for `Attribute`s:   
If an `Attribute` instance is kept around after the last reference to a file was dropped in client code, the order of `Attribute`'s members causes it to first try to close the underlying file before closing its own handle. If the file was opened with close degree `Semi` or the MPI-IO file driver was used, closing the file while the `Attribute` is still open is prohibited. 

This PR, therefore, applies the same fix to `Attribute` as was applied to `Node` in #660; that is, it reorders the member of `Attribute` to ensure that the handle is destroyed first, before attempting to close the file through destroying the link.
